### PR TITLE
:wrench: [UT] Fix warnings with C++17 standard

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -77,7 +77,8 @@ example(test _test)
 example(tmp tmp)
 example(using using)
 
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
+    "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   example(expect expect_cpp17)
   example(test test_cpp17)
   example(suite suite_cpp17)

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2456,7 +2456,8 @@ class steps {
       }
     };
 
-    for (auto i = 0; const auto& step : gherkin_) {
+    decltype(step_) i{};
+    for (const auto& step : gherkin_) {
       if (i++ == step_) {
         call_steps(step, i);
       }


### PR DESCRIPTION
Problem:
- Not all features are available in C++17 standard causing warning with GCC/Clang.

Solution:
- Enable tests in C++17 with GCC.
- Use C++17 features instead of C++20 when GCC/Clang report warnings.