### PR TITLE
Add meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,2 @@
+project('boostut', 'cpp')
+boostut_dep = declare_dependency(include_directories : include_directories('include'))

--- a/meson.build
+++ b/meson.build
@@ -1,2 +1,2 @@
-project('boostut', 'cpp')
+project('boost.ut', 'cpp')
 boostut_dep = declare_dependency(include_directories : include_directories('include'))


### PR DESCRIPTION
Problem:

To work with C++ libraries in meson, the `meson.build` file is required.
If possible, please allow me to add.

We have confirmed that this configuration works properly in our local environment.

- [Subprojects - The Meson Build System](https://mesonbuild.com/Subprojects.html)

Solution:
- add `meson.build` in project root directory
