### PR TITLE
Fix possibility of overflow in den_size()

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -53,6 +53,7 @@ export import std;
 
 #if defined(BOOST_UT_FORWARD) and (__GNUC__ < 10)
 #include <vector>
+#include <cstdint> // std::uintmax_t
 namespace std {
 template <class TLhs, class TRhs>
 auto operator==(TLhs, TRhs) -> bool;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -361,7 +361,7 @@ template <class T, class TValue>
   TValue tmp{};
   do {
     value *= 10;
-    tmp = value - T(value);
+    tmp = value - std::uint64_t(value);
     ++result;
   } while (tmp > precision);
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -361,7 +361,7 @@ template <class T, class TValue>
   TValue tmp{};
   do {
     value *= 10;
-    tmp = value - std::uint64_t(value);
+    tmp = value - std::uintmax_t(value);
     ++result;
   } while (tmp > precision);
 


### PR DESCRIPTION
Problem:
`den_size()` may overflow in the middle of its calculation and fall into an infinite loop

[Minimum Reproduction Code](https://wandbox.org/permlink/kxh8Iu81jKkqHYIu)

Solution:
- Use `std::uintmax_t` instead of `T` in the cast

