### PR TITLE
:bug: [UT] `floating-point` den size can overflow

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -718,7 +718,7 @@ struct value<T, type_traits::requires_t<type_traits::is_floating_point_v<T>>>
   }
 
   constexpr /*explicit(false)*/ value(const T& val)
-      : value{val, T(1) / math::pow(10, math::den_size<int>(val))} {}
+      : value{val, T(1) / math::pow(T(10), math::den_size<unsigned long long>(val))} {}
   [[nodiscard]] constexpr explicit operator T() const { return value_; }
   [[nodiscard]] constexpr decltype(auto) get() const { return value_; }
 
@@ -759,8 +759,8 @@ template <class T, auto N, auto D, auto Size, auto P = 1>
 struct floating_point_constant : op {
   using value_type = T;
 
-  static constexpr auto epsilon = T(1) / math::pow(10, Size - 1);
-  static constexpr auto value = T(P) * (T(N) + (T(D) / math::pow(10, Size)));
+  static constexpr auto epsilon = T(1) / math::pow(T(10), Size - 1);
+  static constexpr auto value = T(P) * (T(N) + (T(D) / math::pow(T(10), Size)));
 
   [[nodiscard]] constexpr auto operator-() const {
     return floating_point_constant<T, N, D, Size, -1>{};
@@ -1852,22 +1852,22 @@ template <char... Cs>
 template <char... Cs>
 [[nodiscard]] constexpr auto operator""_f() {
   return detail::floating_point_constant<
-      float, math::num<unsigned long, Cs...>(), math::den<int, Cs...>(),
-      math::den_size<int, Cs...>()>{};
+      float, math::num<unsigned long, Cs...>(), math::den<unsigned long, Cs...>(),
+      math::den_size<unsigned long, Cs...>()>{};
 }
 
 template <char... Cs>
 [[nodiscard]] constexpr auto operator""_d() {
   return detail::floating_point_constant<
-      double, math::num<unsigned long, Cs...>(), math::den<int, Cs...>(),
-      math::den_size<int, Cs...>()>{};
+      double, math::num<unsigned long, Cs...>(), math::den<unsigned long, Cs...>(),
+      math::den_size<unsigned long, Cs...>()>{};
 }
 
 template <char... Cs>
 [[nodiscard]] constexpr auto operator""_ld() {
   return detail::floating_point_constant<
-      long double, math::num<unsigned long, Cs...>(), math::den<int, Cs...>(),
-      math::den_size<int, Cs...>()>{};
+      long double, math::num<unsigned long long, Cs...>(), math::den<unsigned long long, Cs...>(),
+      math::den_size<unsigned long long, Cs...>()>{};
 }
 [[maybe_unused]] constexpr auto true_b = detail::integral_constant<true>{};
 [[maybe_unused]] constexpr auto false_b = detail::integral_constant<false>{};

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -239,7 +239,9 @@ int main() {
       static_assert(42u == 42_ul);
       static_assert(42.42f == 42.42_f);
       static_assert(42.42 == 42.42_d);
+      static_assert(240.209996948 == 240.209996948);
       static_assert(static_cast<long double>(42.42) == 42.42_ld);
+      static_assert(240.20999694824218 == 240.20999694824218_ld);
       static_assert(0 == 0_i);
       static_assert(10'000 == 10'000_i);
       static_assert(42000'000 == 42000'000_i);


### PR DESCRIPTION
Problem:
- `den_size` for floating point has to respect possible number space.

Solution:
- Use `unsigned long` `unsigned long long` for den_size with `""_d` and `""_ld`.