### PR TITLE
:arrow_up: [ut] Bump version to `1.1.8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ int main() {
 ```cpp
 export module boost.ut; /// __cpp_modules
 
-namespace boost::inline ext::ut::inline v1_1_7 {
+namespace boost::inline ext::ut::inline v1_1_8 {
   /**
    * Represents test suite object
    */
@@ -1458,7 +1458,7 @@ namespace boost::inline ext::ut::inline v1_1_7 {
 
 | Option | Description | Example |
 |-|-|-|
-| `BOOST_UT_VERSION`        | Current version | `1'1'7` |
+| `BOOST_UT_VERSION`        | Current version | `1'1'8` |
 | `BOOST_UT_FORWARD`        | Optionally used in `.cpp` files to speed up compilation of multiple suites | |
 | `BOOST_UT_IMPLEMENTATION` | Optionally used in `main.cpp` file to provide `ut` implementation (have to be used in combination with `BOOST_UT_FORWARD`) | |
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -37,7 +37,7 @@ export import std;
 #elif not defined(__cpp_static_assert)
 #error "[Boost::ext].UT requires support for static assert";
 #else
-#define BOOST_UT_VERSION 1'1'7
+#define BOOST_UT_VERSION 1'1'8
 
 #if defined(__has_builtin) and (__GNUC__ < 10) and not defined(__clang__)
 #undef __has_builtin
@@ -91,7 +91,7 @@ inline namespace ext {
 namespace ut {
 #endif
 
-  inline namespace v1_1_7 {
+  inline namespace v1_1_8 {
   namespace utility {
   class string_view {
    public:
@@ -2553,7 +2553,7 @@ template <bool Constant>
   using operators::operator|;
   using operators::operator/;
   using operators::operator>>;
-  }  // namespace v1_1_7
+  }  // namespace v1_1_8
 }  // namespace ut
 }  // namespace inline ext
 }  // namespace boost


### PR DESCRIPTION
Problem:
- The current version is not reflecting stable/new features.

Solution:
- Update version to `1.1.8`.