### PR TITLE
:new: [Terse] Support for `operator<<`

### DIFF
--- a/example/fatal.cpp
+++ b/example/fatal.cpp
@@ -21,7 +21,7 @@ int main() {
     using boost::ut::expect;
 
     std::optional<int> o{42};
-    expect(o.has_value() >> fatal);
+    expect(o.has_value() >> fatal) << "fatal assertion";
     expect(*o == 42_i);
   };
 
@@ -31,14 +31,15 @@ int main() {
     using boost::ut::that;
 
     std::optional<int> o{42};
-    expect(that % o.has_value() >> fatal and that % *o == 42);
+    expect(that % o.has_value() >> fatal and that % *o == 42)
+        << "fatal assertion";
   };
 
   "fatal terse"_test = [] {
     using namespace boost::ut::operators::terse;
 
     std::optional<int> o{42};
-    o.has_value() >> fatal and*o == 42_i;
+    (o.has_value() >> fatal and *o == 42_i) << "fatal assertion";
   };
 
   using namespace boost::ut::operators;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2074,7 +2074,7 @@ template <class... Ts, class TEvent>
   inline auto operator>>(const T& t,
                          const detail::value_location<detail::fatal>&) {
     using fatal_t = detail::fatal_<T>;
-    struct fatal_ : fatal_t {
+    struct fatal_ : fatal_t, detail::log {
       using type [[maybe_unused]] = fatal_t;
       using fatal_t::fatal_t;
       const detail::terse_<fatal_t> _{*this};
@@ -2086,7 +2086,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator==(
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using eq_t = detail::eq_<T, detail::value_location<typename T::value_type>>;
-    struct eq_ : eq_t {
+    struct eq_ : eq_t, detail::log {
       using type [[maybe_unused]] = eq_t;
       using eq_t::eq_t;
       const detail::terse_<eq_t> _{*this};
@@ -2098,7 +2098,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator==(
       const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
     using eq_t = detail::eq_<detail::value_location<typename T::value_type>, T>;
-    struct eq_ : eq_t {
+    struct eq_ : eq_t, detail::log {
       using type [[maybe_unused]] = eq_t;
       using eq_t::eq_t;
       const detail::terse_<eq_t> _{*this};
@@ -2111,7 +2111,7 @@ template <class... Ts, class TEvent>
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using neq_t =
         detail::neq_<T, detail::value_location<typename T::value_type>>;
-    struct neq_ : neq_t {
+    struct neq_ : neq_t, detail::log {
       using type [[maybe_unused]] = neq_t;
       using neq_t::neq_t;
       const detail::terse_<neq_t> _{*this};
@@ -2136,7 +2136,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator>(
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using gt_t = detail::gt_<T, detail::value_location<typename T::value_type>>;
-    struct gt_ : gt_t {
+    struct gt_ : gt_t, detail::log {
       using type [[maybe_unused]] = gt_t;
       using gt_t::gt_t;
       const detail::terse_<gt_t> _{*this};
@@ -2148,7 +2148,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator>(
       const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
     using gt_t = detail::gt_<detail::value_location<typename T::value_type>, T>;
-    struct gt_ : gt_t {
+    struct gt_ : gt_t, detail::log {
       using type [[maybe_unused]] = gt_t;
       using gt_t::gt_t;
       const detail::terse_<gt_t> _{*this};
@@ -2160,7 +2160,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator>=(
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using ge_t = detail::ge_<T, detail::value_location<typename T::value_type>>;
-    struct ge_ : ge_t {
+    struct ge_ : ge_t, detail::log {
       using type [[maybe_unused]] = ge_t;
       using ge_t::ge_t;
       const detail::terse_<ge_t> _{*this};
@@ -2172,7 +2172,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator>=(
       const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
     using ge_t = detail::ge_<detail::value_location<typename T::value_type>, T>;
-    struct ge_ : ge_t {
+    struct ge_ : ge_t, detail::log {
       using type [[maybe_unused]] = ge_t;
       using ge_t::ge_t;
       const detail::terse_<ge_t> _{*this};
@@ -2184,7 +2184,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator<(
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using lt_t = detail::lt_<T, detail::value_location<typename T::value_type>>;
-    struct lt_ : lt_t {
+    struct lt_ : lt_t, detail::log {
       using type [[maybe_unused]] = lt_t;
       using lt_t::lt_t;
       const detail::terse_<lt_t> _{*this};
@@ -2196,7 +2196,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator<(
       const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
     using lt_t = detail::lt_<detail::value_location<typename T::value_type>, T>;
-    struct lt_ : lt_t {
+    struct lt_ : lt_t, detail::log {
       using type [[maybe_unused]] = lt_t;
       using lt_t::lt_t;
       const detail::terse_<lt_t> _{*this};
@@ -2208,7 +2208,7 @@ template <class... Ts, class TEvent>
   constexpr auto operator<=(
       const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
     using le_t = detail::le_<T, detail::value_location<typename T::value_type>>;
-    struct le_ : le_t {
+    struct le_ : le_t, detail::log {
       using type [[maybe_unused]] = le_t;
       using le_t::le_t;
       const detail::terse_<le_t> _{*this};
@@ -2233,7 +2233,7 @@ template <class... Ts, class TEvent>
                                     type_traits::is_op_v<TRhs>> = 0>
   constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
     using and_t = detail::and_<typename TLhs::type, typename TRhs::type>;
-    struct and_ : and_t {
+    struct and_ : and_t, detail::log {
       using type [[maybe_unused]] = and_t;
       using and_t::and_t;
       const detail::terse_<and_t> _{*this};
@@ -2246,7 +2246,7 @@ template <class... Ts, class TEvent>
                                     type_traits::is_op_v<TRhs>> = 0>
   constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
     using or_t = detail::or_<typename TLhs::type, typename TRhs::type>;
-    struct or_ : or_t {
+    struct or_ : or_t, detail::log {
       using type [[maybe_unused]] = or_t;
       using or_t::or_t;
       const detail::terse_<or_t> _{*this};
@@ -2257,7 +2257,7 @@ template <class... Ts, class TEvent>
   template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
   constexpr auto operator not(const T& t) {
     using not_t = detail::not_<typename T::type>;
-    struct not_ : not_t {
+    struct not_ : not_t, detail::log {
       using type [[maybe_unused]] = not_t;
       using not_t::not_t;
       const detail::terse_<not_t> _{*this};

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1481,6 +1481,7 @@ int main() {
     using ut::fatal;
     using namespace ut::literals;
     using namespace ut::operators::terse;
+    using namespace std::literals::string_view_literals;
 
     auto& test_cfg = ut::cfg<ut::override>;
 
@@ -1495,9 +1496,10 @@ int main() {
     } catch(const ut::events::fatal_assertion&) {}
     2 == 1_i;
     custom{42}%_t == custom{41};
+    (3 >= 4_i) << "fatal";
     // clang-format on
 
-    test_assert(6 == std::size(test_cfg.assertion_calls));
+    test_assert(7 == std::size(test_cfg.assertion_calls));
     test_assert(test_cfg.fatal_assertion_calls > 0);
 
     test_assert("42 == 42" == test_cfg.assertion_calls[0].expr);
@@ -1518,5 +1520,11 @@ int main() {
 
     test_assert("custom{42} == custom{41}" == test_cfg.assertion_calls[5].expr);
     test_assert(not test_cfg.assertion_calls[5].result);
+
+    test_assert("3 >= 4" == test_cfg.assertion_calls[6].expr);
+    test_assert(not test_cfg.assertion_calls[6].result);
+    test_assert(2 == std::size(test_cfg.log_calls));
+    test_assert('\n' == std::any_cast<char>(test_cfg.log_calls[0]));
+    test_assert("fatal"sv == std::any_cast<const char*>(test_cfg.log_calls[1]));
   }
 }


### PR DESCRIPTION
Problem:
- There is no support of streaming messages to out with terse syntax.

Solution:
- Add support for `operator<<` with terse syntax.