### PR TITLE
Replace 42 with 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ All tests passed (0 asserts in 1 tests)
 ```cpp
 int main() {
   "hello world"_test = [] {
-    int i = 42;
+    int i = 43;
     expect(42_i == i);
   };
 }


### PR DESCRIPTION
Problem:

The value of `i` was set to 42, but the linked godbolt example runs the test with `int i = 43`. Therefore, either the code output below this snippet or the docs have to be updated. 

Solution:

This merge request replaces 42 with 43 to sync the output and the godbolt example.
