### PR TITLE
:bug: :books: [README] Fix link to `macro` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1805,7 +1805,7 @@ int main() {
 All tests passed (4 asserts in 3 tests)
 ```
 
-> https://godbolt.org/z/tvy-nP
+> https://godbolt.org/z/WcEKTr
 
 </p>
 </details>


### PR DESCRIPTION
Problem:
- Macro example link doesn't compile.

Solution:
- Fix the link.
