### PR TITLE
CMake: Install config file into architecture-independent location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(package_directory "${CMAKE_INSTALL_LIBDIR}/cmake/ut")
+set(package_directory "${CMAKE_INSTALL_PREFIX}/lib/cmake/ut")
 set(config_output "${CMAKE_CURRENT_BINARY_DIR}/ut-config.cmake")
 
 # Generate config file.


### PR DESCRIPTION
boost-ut is header-only so the CMake config should be installed into the architecture-independent directory to allow it to be found when compiling regardless of the targeted architecture and the architecture it was installed on.