### PR TITLE
:bug: [core] Warning: "Possible misuse of comma operator", Fix #398

### DIFF
--- a/example/fatal.cpp
+++ b/example/fatal.cpp
@@ -14,8 +14,6 @@ int main() {
   using namespace boost::ut::literals;
   using boost::ut::fatal;
 
-  static constexpr auto value = 42;  // Change to std::nullopt
-
   "fatal"_test = [] {
     using namespace boost::ut::operators;
     using boost::ut::expect;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -207,7 +207,8 @@ template <class TPattern, class TStr>
     } else if (pattern[pi] != str[si]) {
       return {};
     }
-    ++pi, ++si;
+    ++pi;
+    ++si;
   }
 
   if (si < str.size() or pi < std::size(pattern)) {


### PR DESCRIPTION
Problem:
- There is a valid warning of potential misuse of comma operator in match function.

Solution:
- Use semicolon instead of a comma to avoid the warning and make the intend cleaner.
- Add gherkin unit test to verify the behaviour of match in an integration test.