### PR TITLE
:bug: [core] `""_b` should print names on failures

### DIFF
--- a/example/benchmark.cpp
+++ b/example/benchmark.cpp
@@ -9,11 +9,11 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 namespace benchmark {
 struct benchmark : boost::ut::detail::test {
-  template <class TName>
-  explicit benchmark(const TName& name)
+  explicit benchmark(std::string_view name)
       : boost::ut::detail::test{"benchmark", name} {}
 
   template <class Test>
@@ -31,7 +31,7 @@ struct benchmark : boost::ut::detail::test {
 
 [[nodiscard]] auto operator""_benchmark(const char* name,
                                         decltype(sizeof("")) size) {
-  return ::benchmark::benchmark{boost::ut::utility::string_view{name, size}};
+  return ::benchmark::benchmark{{name, size}};
 }
 
 #if defined(__GNUC__) or defined(__clang__)

--- a/example/expect.cpp
+++ b/example/expect.cpp
@@ -99,5 +99,6 @@ int main() {
     expect("true"_b);
     expect("true"_b or not "true"_b);
     expect(not "true"_b != "true"_b);
+    expect("has value"_b == "value is set"_b);
   };
 }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -450,6 +450,7 @@ int main() {
                   to_string("true"_b or (42.42_d == 12.34)));
       test_assert("(not 1 == 2 and str == str2)" ==
                   to_string(not(1_i == 2) and ("str"sv == "str2"sv)));
+      test_assert("lhs == rhs" == to_string("lhs"_b == "rhs"_b));
     }
 
     {


### PR DESCRIPTION
Problem:
- When comparing `""_b` operators names aren't printed. Instead true/false are used.
- utility::string_view is not needed.

Solution:
- Introduce a local `named` operator which prints the underlying name.
- Remove utitlity::string_view.