### PR TITLE
Improve CMake build-system (CMakeLists.txt files)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 cmake_minimum_required(VERSION 3.1)
-project(boost.ut CXX)
+project(boost.ut VERSION 1.1.8 LANGUAGES CXX)
 
 include(CTest)
 
@@ -24,11 +24,25 @@ option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If di
 option(BOOST_UT_BUILD_BENCHMARKS "Build the benchmarks" ${MASTER_PROJECT})
 option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${MASTER_PROJECT})
 option(BOOST_UT_BUILD_TESTS "Build the tests" ${MASTER_PROJECT})
+option(BUILD_UT_ENABLE_CPP17_EXAMPLES "Use C++17 examples for boost.ut" ON)
+
+
+# -- ARTIFACT DIRECTORY LAYOUT in CMAKE_CURRENT_BINARY_DIR/PROJECT_BINARY_DIR:
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+
 
 add_library(boost.ut INTERFACE)
-target_include_directories(boost.ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+target_include_directories(boost.ut INTERFACE
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+target_compile_features(boost.ut INTERFACE cxx_std_20)
 add_library(boost::ut ALIAS boost.ut)
 
+message(STATUS "USING: CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID} (compiler.version: ${CMAKE_CXX_COMPILER_VERSION})")
+message(STATUS "USING: CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} (required: ${CMAKE_CXX_STANDARD_REQUIRED}, extensions: ${CMAKE_CXX_EXTENSIONS})")
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   if (WIN32) # clang-cl
     target_compile_options(boost.ut INTERFACE
@@ -54,7 +68,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
                         -Wno-class-varargs
                         -Wno-padded
                         -Wno-missing-prototypes
-                        -Wno-ctad-maybe-unsupported)
+                        -Wno-ctad-maybe-unsupported
+                        # -- TO-BE-DISCUSSED:
+                        # NEEDED-BY: AppleClang 12.x, clang-10, ...
+                        -Wno-missing-field-initializers
+                        # MAYBE: -Wno-error=missing-field-initializers
+        )
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   target_compile_options(boost.ut INTERFACE
@@ -85,7 +104,14 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
                       -Wduplicated-branches
                       -Wcast-align=strict
                       -Wmissing-include-dirs
-                      -Wno-missing-declarations)
+                      -Wno-missing-declarations
+                      # -- TO-BE-DISCUSSED:
+                      # NEEDED-BY: gcc-10, ...
+                      -Wno-missing-field-initializers
+                      # MAYBE: -Wno-error=float-equal
+                      # -- REQUIRED-FOR: gcc-9.x
+                      -Wno-error=undef
+  )
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   target_compile_options(boost.ut INTERFACE
                       /W4
@@ -123,14 +149,22 @@ function(ut_add_custom_command_or_test)
           ${ARGN})
 
   if (BOOST_UT_ENABLE_RUN_AFTER_BUILD)
-    add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
+    add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND}
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    )
   else()
-    add_test(NAME ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
+    add_test(NAME ${PARSE_TARGET} COMMAND ${PARSE_COMMAND}
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    )
   endif()
 endfunction()
 
-include_directories(include)
+# AVOID: include_directories(include)
+# USE INSTEAD: target_link_librries(my_target PUBLIC boost::ut)
 
+if (BOOST_UT_BUILD_BENCHMARKS OR BOOST_UT_BUILD_EXAMPLES OR BOOST_UT_BUILD_TESTS)
+  enable_testing()
+endif()
 if (BOOST_UT_BUILD_BENCHMARKS)
   add_subdirectory(benchmark)
 endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,10 +4,14 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
+
 function(benchmark name file)
-  add_executable(b${name} ${file}.cpp)
-  target_compile_options(b${name} PRIVATE ${ARGN})
-  ut_add_custom_command_or_test(TARGET b${name} COMMAND b${name})
+  add_executable(benchmark_${name} ${file}.cpp)
+  target_link_libraries(benchmark_${name} PRIVATE boost::ut)
+  # target_compile_options(benchmark_${name} PRIVATE ${ARGN})
+  target_compile_definitions(benchmark_${name} PRIVATE ${ARGN})
+  ut_add_custom_command_or_test(TARGET benchmark_${name} COMMAND benchmark_${name})
+  add_test(NAME benchmark.${name} COMMAND benchmark_${name})
 endfunction()
 
 benchmark(expect_udl expect "-DEXPECT_UDL")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,30 +6,55 @@
 #
 find_program(BOOST_UT_MEMORYCHECK_COMMAND valgrind)
 
+# -- REQUIRED FOR: AppleClang 12.0
+# NEEDED-BY: boost::ut
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    message(STATUS "USING: CXX_COMPILER_EXTRA_OPTIONS in ${CMAKE_CURRENT_SOURCE_DIR}")
+    set(example_CXX_COMPILER_EXTRA_OPTIONS
+        -Wno-shadow-field
+        -Wno-shadow-uncaptured-local
+        -Wno-sign-conversion
+    )
+endif()
+
+
 function(example file target)
+  set(_example_EXTRA_LIBS ${${target}_EXTRA_LIBS})
+  if(_example_EXTRA_LIBS)
+    message(STATUS "example: ${target}_EXTRA_LIBS= ${_example_EXTRA_LIBS}")
+  endif()
+
   add_executable(boost_ut_${target} ${file}.cpp)
+  target_link_libraries(boost_ut_${target} PRIVATE boost::ut ${_example_EXTRA_LIBS})
   if(${target} MATCHES "_cpp17$")
     set_property(TARGET boost_ut_${target} PROPERTY CXX_STANDARD 17)
   endif()
   if(BOOST_UT_ENABLE_MEMCHECK AND BOOST_UT_MEMORYCHECK_COMMAND)
     ut_add_custom_command_or_test(TARGET boost_ut_${target} COMMAND ${BOOST_UT_MEMORYCHECK_COMMAND}
                                   --leak-check=full --error-exitcode=1 ./boost_ut_${target} ${ARGN})
+    add_test(NAME example.memcheck.${target}
+        COMMAND ${BOOST_UT_MEMORYCHECK_COMMAND} --leak-check=full --error-exitcode=1 ./boost_ut_${target} ${ARGN}
+        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    )
   else()
     ut_add_custom_command_or_test(TARGET boost_ut_${target} COMMAND boost_ut_${target} ${ARGN})
   endif()
+  add_test(NAME example.${target} COMMAND boost_ut_${target} ${ARGN})
 endfunction()
+
 
 example(cfg/printer printer)
 example(cfg/runner runner)
 
-example(cfg/parallel_runner parallel_runner)
 if (DEFINED ENV{TBB_ROOT})
   set(TBB_ROOT $ENV{TBB_ROOT})
   include(${TBB_ROOT}/cmake/TBBBuild.cmake)
   tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver="c++17")
   find_package(TBB)
-  target_link_libraries(boost_ut_parallel_runner ${TBB_IMPORTED_TARGETS})
+  # DISABLED: target_link_libraries(boost_ut_parallel_runner PRIVATE ${TBB_IMPORTED_TARGETS})
+  set(parallel_runner_EXTRA_LIBS ${TBB_IMPORTED_TARGETS})
 endif()
+example(cfg/parallel_runner parallel_runner)
 
 example(cfg/reporter reporter)
 
@@ -49,9 +74,15 @@ example(exception exception)
 example(expect expect)
 example(fatal fatal)
 example(filter filter)
-if (NOT WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-example(gherkin gherkin)
-example(gherkin gherkin_feature "../../example/gherkin.feature")
+
+if(NOT WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  example(gherkin gherkin)
+  example(gherkin gherkin_feature "../../example/gherkin.feature")
+
+  # -- SPECIALIZE COMPILER-OPTIONS:
+  # NEEDED-BY: boost::ut
+  target_compile_options(boost_ut_gherkin         PRIVATE ${example_CXX_COMPILER_EXTRA_OPTIONS})
+  target_compile_options(boost_ut_gherkin_feature PRIVATE ${example_CXX_COMPILER_EXTRA_OPTIONS})
 endif()
 example(hello_world hello_world)
 example(log log)
@@ -61,8 +92,9 @@ example(minimal minimal)
 example(mut mut)
 example(matcher matcher)
 
-if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
   example(parameterized parameterized)
+  target_compile_options(boost_ut_parameterized  PRIVATE ${example_CXX_COMPILER_EXTRA_OPTIONS})
 endif()
 
 example(run run)
@@ -78,6 +110,7 @@ example(test _test)
 example(tmp tmp)
 example(using using)
 
+if(BUILD_UT_ENABLE_CPP17_EXAMPLES)
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
     "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   example(expect expect_cpp17)
@@ -89,3 +122,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
   example(should should_cpp17)
   example(skip skip_cpp17)
 endif()
+endif()
+
+# -- SPECIALIZE COMPILER-OPTIONS:
+# NEEDED-BY: boost::ut
+target_compile_options(boost_ut_benchmark  PRIVATE ${example_CXX_COMPILER_EXTRA_OPTIONS})

--- a/example/expect.cpp
+++ b/example/expect.cpp
@@ -98,7 +98,7 @@ int main() {
   "boolean"_test = [] {
     expect("true"_b);
     expect("true"_b or not "true"_b);
-    expect(not "true"_b != "true"_b);
+    expect((not "true"_b) != "true"_b);     // FIXED: parenthesis compiler-warning/error.
     expect("has value"_b == "value is set"_b);
   };
 }

--- a/example/terse.cpp
+++ b/example/terse.cpp
@@ -34,7 +34,7 @@ int main() {
   "terse"_test = [] {
     6_i == sum(1, 2, 3);
     sum(1, 1) == 2_i;
-    42_i == sum(40, 2) and 0_i != sum(1) or 4_i == 3;
+    (42_i == sum(40, 2) and 0_i != sum(1)) or (4_i == 3);   // FIXED: compiler-warning/error due to missing parenthesis (clang, gcc-10, ..)
   };
 
   // clang-format off

--- a/test/ft/CMakeLists.txt
+++ b/test/ft/CMakeLists.txt
@@ -4,12 +4,15 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-include_directories(include)
 
 add_executable(ft main.cpp test_suite_1.cpp test_suite_2.cpp test_suite_3.cpp)
+target_link_libraries(ft PRIVATE boost::ut)
+target_include_directories(ft PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ut_add_custom_command_or_test(TARGET ft COMMAND ft)
 
 add_executable(ft-no-exceptions main.cpp test_suite_1.cpp test_suite_2.cpp test_suite_3.cpp)
+target_link_libraries(ft-no-exceptions PRIVATE boost::ut)
+target_include_directories(ft-no-exceptions PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ut_add_custom_command_or_test(TARGET ft-no-exceptions COMMAND ft-no-exceptions)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
@@ -30,5 +33,18 @@ endif()
 
 if (NOT WIN32) # WIN32 includes both MSVC and clang-cl
   add_executable(ft-link main.cpp test_suite_1.cpp test_suite_2.cpp test_suite_3.cpp)
+  target_link_libraries(ft-link PRIVATE boost::ut)
+  target_include_directories(ft-link PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
   ut_add_custom_command_or_test(TARGET ft-link COMMAND ft-link)
+endif()
+
+
+# ---------------------------------------------------------------------------
+# CTEST DESCRIPTION
+# ---------------------------------------------------------------------------
+# ALREADY: enable_testing()
+add_test(NAME test.ft COMMAND ft)
+add_test(NAME test.ft-no-exceptions COMMAND ft-no-exceptions)
+if(TARGET ft-link)
+    add_test(NAME test.ft-link COMMAND ft-link)
 endif()

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -4,19 +4,57 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
+
 find_program(BOOST_UT_MEMORYCHECK_COMMAND valgrind)
 
+# -- REQUIRED FOR: AppleClang 12.0, clang-10, gcc-10, ...
+# NEEDED-BY: boost::ut
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    message(STATUS "USING: CXX_COMPILER_EXTRA_OPTIONS in ${CMAKE_CURRENT_SOURCE_DIR}")
+    set(boost_ut_executable_CXX_COMPILER_EXTRA_OPTIONS
+        -Wno-missing-noreturn
+        -Wno-shadow-field-in-constructor
+        -Wno-shadow-uncaptured-local
+        -Wno-double-promotion
+        -Wno-float-equal
+        -Wno-error=float-equal
+        -Wno-sign-conversion
+        -Wno-error=sign-conversion
+        -Wno-implicit-float-conversion
+        # DISABLED: -Wno-implicit-int-float-conversion
+    )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+    message(STATUS "USING: CXX_COMPILER_EXTRA_OPTIONS in ${CMAKE_CURRENT_SOURCE_DIR}")
+    set(boost_ut_executable_CXX_COMPILER_EXTRA_OPTIONS
+        -Wno-sign-conversion
+        -Wno-error=sign-conversion
+        -Wno-float-equal
+        -Wno-error=float-equal
+    )
+endif()
+
+
 if (BOOST_UT_ENABLE_MEMCHECK AND BOOST_UT_MEMORYCHECK_COMMAND)
-  function(ut name)
-    add_executable(${name} ${name}.cpp)
-    ut_add_custom_command_or_test(TARGET ${name} COMMAND ${BOOST_UT_MEMORYCHECK_COMMAND}
-        --leak-check=full --error-exitcode=1 ./${name})
+  message(STATUS "USING: MEMCHECK enabled (using: ${BOOST_UT_MEMORYCHECK_COMMAND})")
+  function(boost_ut_executable name)
+    add_executable(test_${name} ${name}.cpp)
+    target_link_libraries(test_${name} PRIVATE boost::ut)
+    target_compile_options(test_${name} PRIVATE ${boost_ut_executable_CXX_COMPILER_EXTRA_OPTIONS})
+    ut_add_custom_command_or_test(TARGET test_${name} COMMAND ${BOOST_UT_MEMORYCHECK_COMMAND}
+        --leak-check=full --error-exitcode=1 ./test_${name})
+    add_test(NAME test.${name} COMMAND test_${name})
+    add_test(NAME test.memcheck.${name}
+        COMMAND ${BOOST_UT_MEMORYCHECK_COMMAND} --leak-check=full --error-exitcode=1 ./test_${name}
+    )
   endfunction()
 else()
-  function(ut name)
-    add_executable(${name} ${name}.cpp)
-    ut_add_custom_command_or_test(TARGET ${name} COMMAND ${name})
+  function(boost_ut_executable name)
+    add_executable(test_${name} ${name}.cpp)
+    target_link_libraries(test_${name} PUBLIC boost::ut)
+    target_compile_options(test_${name} PRIVATE ${boost_ut_executable_CXX_COMPILER_EXTRA_OPTIONS})
+    ut_add_custom_command_or_test(TARGET test_${name} COMMAND test_${name})
+    add_test(NAME test.${name} COMMAND test_${name})
   endfunction()
 endif()
 
-ut(ut)
+boost_ut_executable(ut)

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -323,7 +323,7 @@ int main() {
 
     {
       static_assert("true"_b);
-      static_assert(not "true"_b != "true"_b);
+      static_assert((not "true"_b) != "true"_b);    // FIXED: clang/gcc compiler-warning/error related to missing parenthesis.
       static_assert("named"_b);
       static_assert(42 == 42_i);
       static_assert(0u == 0_u);
@@ -338,7 +338,7 @@ int main() {
       static_assert(42u == 42_ul);
       static_assert(42.42f == 42.42_f);
       static_assert(42.42 == 42.42_d);
-      static_assert(240.209996948 == 240.209996948);
+      static_assert(240.209996948 == 240.209996948);    // gcc-10: [-Werror=float-equal] error: comparing floating-point with '==' or '!=' is unsafe
       static_assert(static_cast<long double>(42.42) == 42.42_ld);
       static_assert(240.20999694824218 == 240.20999694824218_ld);
       static_assert(0 == 0_i);
@@ -421,7 +421,7 @@ int main() {
       test_assert(43 >= 42_i);
       test_assert(42 <= 42_i);
       test_assert(42 <= 43_i);
-      test_assert(not "true"_b == not "true"_b);
+      test_assert((not "true"_b) == not "true"_b);  // FIXED: clang/gcc compiler-warning/error related to missing parenthesis.
     }
 
     {
@@ -1536,7 +1536,7 @@ int main() {
     // clang-format off
     42_i == 42;
     1 == 2_i;
-    0_i == 1 and 1_i > 2 or 3 <= 3_i;
+    (0_i == 1 and 1_i > 2) or (3 <= 3_i);   // FIXED: clang/gcc compiler-warning/error related to missing parenthesis.
     try {
     ("true"_b == false) >> fatal and 1_i > 0;
     } catch(const ut::events::fatal_assertion&) {}


### PR DESCRIPTION
Changes (details):
* executable(s): Depend on "boost::ut" header-only library via target_link_libraries()
* REMOVE: include_directories(include) => USE: target_link_libraries() inheritance instance
  HINT: Normal mechanism for "Modern CMake".
* ADD/USE: CMake/ctest add_test() macros
* compiler_options: Weaken to strict compiler_options from boost::ut library where needed.
* USE: ARTIFACT DIRECTORY LAYOUT definitions to place all executable into one directory within the CMAKE_BINARY_DIRECTORY (`build*/bin/` directory, etc.)
* test/ut/: Rename function "ut()" to "boost_ut_executable()" (reason: better name; more readable).

Problem:
- Improve CMake build system support and add tests (as normally used in CMake/ctest).

Solution:
- See detailed description above
- Use "Modern CMake" constructs to simplify reusing the header-only library w/ other executables.

HINTS (`boost::ut compiler-options`: not fixed):
The current compiler-options are too strict (on macOS with AppleClang 12.x).
This can easily be seen because the provided executables (in examples/, test/*/ directory) needed weaker compiler options to compile. This was not detected because these executables did not specify a dependency to the `boost::ut` library via `target_link_libraries()` construct and therefore did not inherit the `boost::ut` compiler-options.

Reviewers:
@anybody
