### PR TITLE
:wrench: Mark `ut::cfg` inline when overriden, Fix #402

### DIFF
--- a/example/cfg/parallel_runner.cpp
+++ b/example/cfg/parallel_runner.cpp
@@ -41,8 +41,8 @@ class parallel_runner : public ut::runner<> {
 };
 }  // namespace cfg
 
-template <>
-auto ut::cfg<ut::override> = cfg::parallel_runner{};
+template <class... Ts>
+inline auto ut::cfg<ut::override, Ts...> = cfg::parallel_runner{};
 
 ut::suite parallel_1 = [] {
   using namespace ut;


### PR DESCRIPTION
Problem:
- When `ut::cfg` is overridden and included by multiple files it has to be marked inline.

Solution:
- Add inline to `ut::cfg` in examples.