### PR TITLE
fix GCC warning -Wmissing-field-initializers

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1654,7 +1654,7 @@ constexpr auto operator""_b(const char* name, decltype(sizeof("")) size) {
       return other;
     }
   };
-  return named{{name, size}};
+  return named{{name, size}, {}};
 }
 }  // namespace literals
 


### PR DESCRIPTION
Problem:
- GCC warns about a missing initializer

Solution:
- add the missing initializer

