### PR TITLE
:bug: [core] Add user-defined literals and type aliases for unsigned …

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1592,6 +1592,11 @@ template <char... Cs>
 }
 
 template <char... Cs>
+[[nodiscard]] constexpr auto operator""_sc() {
+  return detail::integral_constant<math::num<signed char, Cs...>()>{};
+}
+
+template <char... Cs>
 [[nodiscard]] constexpr auto operator""_l() {
   return detail::integral_constant<math::num<long, Cs...>()>{};
 }
@@ -1619,6 +1624,11 @@ template <char... Cs>
 template <char... Cs>
 [[nodiscard]] constexpr auto operator""_ul() {
   return detail::integral_constant<math::num<unsigned long, Cs...>()>{};
+}
+
+template <char... Cs>
+[[nodiscard]] constexpr auto operator""_ull() {
+  return detail::integral_constant<math::num<unsigned long long, Cs...>()>{};
 }
 
 template <char... Cs>
@@ -2054,6 +2064,7 @@ template <class TExpr>
 
 using _b = detail::value<bool>;
 using _c = detail::value<char>;
+using _sc = detail::value<signed char>;
 using _s = detail::value<short>;
 using _i = detail::value<int>;
 using _l = detail::value<long>;
@@ -2062,6 +2073,7 @@ using _u = detail::value<unsigned>;
 using _uc = detail::value<unsigned char>;
 using _us = detail::value<unsigned short>;
 using _ul = detail::value<unsigned long>;
+using _ull = detail::value<unsigned long long>;
 using _f = detail::value<float>;
 using _d = detail::value<double>;
 using _ld = detail::value<long double>;
@@ -2270,6 +2282,7 @@ using literals::operator""_b;
 using literals::operator""_i;
 using literals::operator""_s;
 using literals::operator""_c;
+using literals::operator""_sc;
 using literals::operator""_l;
 using literals::operator""_ll;
 using literals::operator""_u;
@@ -2279,6 +2292,7 @@ using literals::operator""_ul;
 using literals::operator""_f;
 using literals::operator""_d;
 using literals::operator""_ld;
+using literals::operator""_ull;
 
 using operators::operator==;
 using operators::operator!=;

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -369,17 +369,28 @@ int main() {
     }
 
     {
+      static_assert(not std::is_same_v<decltype(_sc(42)), decltype(_c(42))>);
+      static_assert(not std::is_same_v<decltype(42_sc), decltype(42_c)>);
+      static_assert(not std::is_same_v<decltype(_sc(42)), decltype(_uc(42u))>);
+      static_assert(not std::is_same_v<decltype(42_sc), decltype(42_uc)>);
+    }
+
+    {
       static_assert(_i(42) == 42_i);
       static_assert(_b(true));
       static_assert(not _b(false));
       static_assert(_s(42) == 42_s);
       static_assert(_c(42) == 42_c);
+      static_assert(_sc(42) == 42_sc);
       static_assert(_l(42) == 42_l);
       static_assert(_ll(42) == 42_ll);
       static_assert(_uc(42u) == 42_uc);
       static_assert(_us(42u) == 42_us);
       static_assert(_us(42u) == 42_us);
       static_assert(_ul(42u) == 42_ul);
+      static_assert(_ull(42u) == 42_ull);
+      static_assert(_ull(18'446'744'073'709'551'615ull) ==
+                    18'446'744'073'709'551'615_ull);
     }
 
     {


### PR DESCRIPTION
…long long and signed char, Fix #409

Problem:
- Currently there are user defined literals and type aliases for char, unsigned char, short, unsigned short, int, unsigned, long, unsigned long, long long, float, double, long double (and with slightly different behavior bool).
  But there's no such thing for signed char or unsigned long long.

Solution:
- Add missing _sc and _ull literals.