### PR TITLE
Specifcy maximum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.19)
 project(boost.ut CXX)
 
 include(CTest)


### PR DESCRIPTION
Problem:
- Projects importing boost.ut as a subproject will see "Policy CMP0077
  is not set..." warning if they set any of the CMake options and are
  using CMake version >= 3.13.

Solution:
 - Specify a maximum version of 3.19 to cmake_minimum_required. This can
   max can be periodically increased as new versions of CMake are
   released.