### PR TITLE
:white_check_mark: :bug: [ut] Fix float-equal double comparison

### DIFF
--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -338,12 +338,12 @@ int main() {
       static_assert(42u == 42_ul);
       static_assert(42.42f == 42.42_f);
       static_assert(42.42 == 42.42_d);
-      static_assert(240.209996948 == 240.209996948);
+      static_assert(240.209996948 == 240.209996948_d);
       static_assert(static_cast<long double>(42.42) == 42.42_ld);
       static_assert(240.20999694824218 == 240.20999694824218_ld);
       static_assert(0 == 0_i);
       static_assert(10'000 == 10'000_i);
-      static_assert(42000'000 == 42000'000_i);
+      static_assert(42'000'000 == 42'000'000_i);
       static_assert(9'999 == 9'999_i);
       static_assert(42 == 42_i);
       static_assert(-42 == -42_i);


### PR DESCRIPTION
Problem
- gcc10 complains about float-equal comparison of floating point.

Solution:
- Fix the test by using _d UDL when comparing big floating point values.