### PR TITLE
:wrench: [CMake] `boost.ut` alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ else()
 endif()
 
 add_library(ut INTERFACE)
+add_library(boost.ut ALIAS ut)
 
 set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)
 # XXX variant: set(INCLUDE_INSTALL_DIR include)


### PR DESCRIPTION
Problem:
- boost.ut and ut are used by users but only ut is exposed.

Solution:
- Add boost.ut alias for ut.