### PR TITLE
Fix compilation error with __cpp_modules

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2312,6 +2312,8 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace v1_1_8
 }  // namespace ut
+#if !defined(__cpp_modules)
 }  // namespace inline ext
 }  // namespace boost
+#endif
 #endif


### PR DESCRIPTION
Problem:
- `ut.hpp` doesn't compile when `__cpp_modules` is defined

Solution:
- Correctly close namespaces conditionally (as noted from https://github.com/microsoft/vscode-cpptools/issues/7150#issuecomment-796966568)

Issue: #432

Reviewers:
@michaelvlach can you please verify that this works on your end?
