### PR TITLE
Improve Meson support - use `override_dependency()` in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,2 +1,5 @@
 project('boost.ut', 'cpp')
 boostut_dep = declare_dependency(include_directories : include_directories('include'))
+if meson.version().version_compare('>=0.54.0')
+  meson.override_dependency('boost.ut', boostut_dep)
+endif


### PR DESCRIPTION
Problem:
- When using ut as a Meson subproject, users have to do `dependency('boost.ut', fallback: ['ut', 'boostut_dep'])`.

Solution:
- Using Meson's 0.54 `override_dependency()`, users can now type `dependency('boost.ut', fallback: 'ut')`, saving a few characters and avoiding having to type the exact dependency variable name.

This does not affect users currently using the old method.
