### PR TITLE
Add option to disable module with c++20.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(BOOST_UT_ENABLE_SANITIZERS "Run static analysis" OFF)
 option(BOOST_UT_BUILD_BENCHMARKS "Build the benchmarks" ${MASTER_PROJECT})
 option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${MASTER_PROJECT})
 option(BOOST_UT_BUILD_TESTS "Build the tests" ${MASTER_PROJECT})
+option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
 
 # ---- Add dependencies via CPM ----
 # see https://github.com/cpm-cmake/CPM.cmake for more info
@@ -129,6 +130,10 @@ endif()
 
 if(BOOST_UT_ENABLE_SANITIZERS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak -fsanitize=undefined")
+endif()
+
+if(BOOST_UT_DISABLE_MODULE)
+  target_compile_definitions(ut INTERFACE BOOST_UT_DISABLE_MODULE)
 endif()
 
 # Create target Boost::ut and install target

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -5,7 +5,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#if defined(__cpp_modules)
+#if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
 export module boost.ut;
 export import std;
 #else
@@ -66,7 +66,7 @@ export import std;
 #include <exception>
 #endif
 
-#if defined(__cpp_modules)
+#if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
 export namespace boost::inline ext::ut {
 #else
 namespace boost {
@@ -2312,7 +2312,7 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace v1_1_8
 }  // namespace ut
-#if !defined(__cpp_modules)
+#if !defined(__cpp_modules) || defined(BOOST_UT_DISABLE_MODULE)
 }  // namespace inline ext
 }  // namespace boost
 #endif


### PR DESCRIPTION
Problem:
- Some compilers enable __cpp_module even if the header file is not used as module. This results in a compilation error with newer compilers like MSVC 19.29 (VS 16.10).

Solution:
- Add a macro to disable module in c++20.

Issue: Fixes #441

Reviewers:
@
