### PR TITLE
Reduce clang-tidy errors and warnings

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -231,6 +231,9 @@ template <class T>
 [[nodiscard]] constexpr auto type_name() -> std::string_view {
 #if defined(_MSC_VER) and not defined(__clang__)
   return {&__FUNCSIG__[120], sizeof(__FUNCSIG__) - 128};
+#elif defined(__clang_analyzer__)
+  // clang-tidy doesn't include inline namespaces in the qualified name.
+  return {&__PRETTY_FUNCTION__[57], sizeof(__PRETTY_FUNCTION__) - 59};
 #elif defined(__clang__)
   return {&__PRETTY_FUNCTION__[70], sizeof(__PRETTY_FUNCTION__) - 72};
 #elif defined(__GNUC__)

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -151,7 +151,8 @@ template <class TPattern, class TStr>
 [[nodiscard]] constexpr auto match(const TPattern& pattern, const TStr& str)
     -> std::vector<TStr> {
   std::vector<TStr> groups{};
-  auto pi = 0u, si = 0u;
+  auto pi = 0u;
+  auto si = 0u;
 
   const auto matcher = [&](char b, char e, char c = 0) {
     const auto match = si;
@@ -258,31 +259,21 @@ template <class T, char... Cs>
 [[nodiscard]] constexpr auto num() -> T {
   static_assert(
       ((Cs == '.' or Cs == '\'' or (Cs >= '0' and Cs <= '9')) and ...));
-  constexpr const char cs[]{Cs...};
   T result{};
-  auto size = 0u, i = 0u, tmp = 1u;
-
-  while (i < sizeof...(Cs) and cs[i] != '.') {
-    if (cs[i++] != '\'') {
-      ++size;
+  for (const char c : {Cs...}) {
+    if (c == '.') {
+      break;
     }
-  }
-
-  i = {};
-  while (i < sizeof...(Cs) and cs[i] != '.') {
-    if (cs[i] == '\'') {
-      --tmp;
-    } else {
-      result += pow(T(10), size - i - tmp) * T(cs[i] - '0');
+    if (c >= '0' and c <= '9') {
+      result = result * T(10) + T(c - '0');
     }
-    ++i;
   }
   return result;
 }
 
 template <class T, char... Cs>
 [[nodiscard]] constexpr auto den() -> T {
-  constexpr const char cs[]{Cs...};
+  constexpr const std::array cs{Cs...};
   T result{};
   auto i = 0u;
   while (cs[i++] != '.') {
@@ -296,7 +287,7 @@ template <class T, char... Cs>
 
 template <class T, char... Cs>
 [[nodiscard]] constexpr auto den_size() -> T {
-  constexpr const char cs[]{Cs...};
+  constexpr const std::array cs{Cs...};
   T i{};
   while (cs[i++] != '.') {
   }
@@ -928,8 +919,7 @@ struct colors {
 
 class printer {
   [[nodiscard]] inline auto color(const bool cond) {
-    const std::string_view colors[] = {colors_.fail, colors_.pass};
-    return colors[cond];
+    return cond ? colors_.pass : colors_.fail;
   }
 
  public:


### PR DESCRIPTION
Problem:
- the following error is reported because clang-tidy doesn't include inline namespaces in the qualified name:
```
test/ut/ut.cpp:286:21: error: static_assert expression is not an integral constant expression [clang-diagnostic-error]
      static_assert("void"sv ==
                    ^
/Users/runner/work/ut/ut/build/../include/boost/ut.hpp:234:12: note: cannot refer to element 70 of array of 63 elements in a constant expression
  return {&__PRETTY_FUNCTION__[70], sizeof(__PRETTY_FUNCTION__) - 72};
```
- clang-tidy reports the following warnings:
```
include/boost/ut.hpp:263:3: warning: multiple declarations in a single statement reduces readability [readability-isolate-declaration]

include/boost/ut.hpp:285:19: warning: do not declare C-style arrays, use std::array<> instead [modernize-avoid-c-arrays]
```

Solution:
- Add preprocessor check for `__clang_analyzer__` and reduce prefix length by 13 for the two inline namespaces (`::ext`, `::v1_1_8`.
- Replace C-style arrays with `std::array`. Refactor `math::num` and `printer::color` to remove array usage.
- Separate multiple variable declarations to individual statements.

Issue: #423

Reviewers:
@krzysztof-jusiak 