### PR TITLE
Avoid C4702 "unreachable code" in MSVC release mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build*
 /CMakeSettings.json
 /.vs
+cmake-build-*/
+.idea/

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -848,12 +848,12 @@ struct throws_ : op {
       : value_{[&expr] {
           try {
             expr();
+            return false;
           } catch (const TException&) {
             return true;
           } catch (...) {
             return false;
           }
-          return false;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -867,10 +867,10 @@ struct throws_<TExpr, void> : op {
       : value_{[&expr] {
           try {
             expr();
+            return false;
           } catch (...) {
             return true;
           }
-          return false;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -884,10 +884,10 @@ struct nothrow_ : op {
       : value_{[&expr] {
           try {
             expr();
+            return true;
           } catch (...) {
             return false;
           }
-          return true;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -846,14 +846,14 @@ template <class TExpr, class TException = void>
 struct throws_ : op {
   constexpr explicit throws_(const TExpr& expr)
       : value_{[&expr] {
+          bool ret_val {false};
           try {
             expr();
-            return false;
           } catch (const TException&) {
-            return true;
+            ret_val = true;
           } catch (...) {
-            return false;
           }
+          return ret_val;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -865,12 +865,13 @@ template <class TExpr>
 struct throws_<TExpr, void> : op {
   constexpr explicit throws_(const TExpr& expr)
       : value_{[&expr] {
+          bool ret_val{false};
           try {
             expr();
-            return false;
           } catch (...) {
-            return true;
+            ret_val = true;
           }
+          return ret_val;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -882,12 +883,13 @@ template <class TExpr>
 struct nothrow_ : op {
   constexpr explicit nothrow_(const TExpr& expr)
       : value_{[&expr] {
+          bool ret_val{true};
           try {
             expr();
-            return true;
           } catch (...) {
-            return false;
+            ret_val = false;
           }
+          return ret_val;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }


### PR DESCRIPTION
Problem:
- [compiler-warning-level-4-c4702](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702?view=msvc-160) would trigger on the default/second `return` statement in MSVC when compiling in release mode.
At first I tried just moving the `return` statement to inside the `try` block, but the error still occurred.

Solution:
- Single `return` statement using a `bool` variable that gets toggled to `true`/`false` depending on if any `catch` statements are ran. 

fixes:  https://github.com/boost-ext/ut/issues/443

Reviewers:
@
