### PR TITLE
:new: [example] Attr/define

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -49,6 +49,7 @@ if(NOT WIN32)
   example(abort abort)
 endif()
 
+example(attr attr)
 example(BDD BDD)
 example(benchmark benchmark)
 example(cli cli_pass "cli.pass")

--- a/example/attr.cpp
+++ b/example/attr.cpp
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2019-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/ut.hpp>
+
+constexpr auto sum = [](auto... args) { return (0 + ... + args); };
+
+int main() {
+  using boost::ut::operator""_test;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+
+  "macro"_test = [] {
+    #define expect
+    expect sum(1, 1) == 2_i;
+    expect(6_i == sum(1, 2, 3));
+    #undef expect
+  };
+
+  #if __has_cpp_attribute(expect)
+  "attribute"_test = [] {
+    [[expect]] 3_i == sum(1, 2);
+    [[expect]] (sum(1, 2) == 3_i);
+  };
+  #endif
+}


### PR DESCRIPTION
Problem:
- There is no example how assert/attributes can be used for explicit syntax.

Solution:
- Add example/attr to show the use case.
