### PR TITLE
Use built-in comma operator to evaluate expression

### DIFF
--- a/example/attr.cpp
+++ b/example/attr.cpp
@@ -15,7 +15,7 @@ int main() {
   using namespace boost::ut::operators::terse;
 
   "macro"_test = [] {
-    #define expect 0,
+    #define expect void(),
     expect sum(1, 1) == 2_i;
     expect(6_i == sum(1, 2, 3));
     #undef expect

--- a/example/attr.cpp
+++ b/example/attr.cpp
@@ -15,7 +15,7 @@ int main() {
   using namespace boost::ut::operators::terse;
 
   "macro"_test = [] {
-    #define expect
+    #define expect 0,
     expect sum(1, 1) == 2_i;
     expect(6_i == sum(1, 2, 3));
     #undef expect


### PR DESCRIPTION
Problem:
- Broken macOS CI build due to the following error:
```
../example/attr.cpp:20:16: error: expression result unused [-Werror,-Wunused-value]
    expect(6_i == sum(1, 2, 3));
           ~~~~^~~~~~~~~~~~~~~
1 error generated.
```

Solution:
- Define expect macro using the comma operator to force the use of the expression value.
- Tested solution on macOS local build.

Issue: #

Reviewers:
@krzysztof-jusiak 
