### PR TITLE
:new: [core] Support for easy comparison of function result type

### DIFF
--- a/example/tmp.cpp
+++ b/example/tmp.cpp
@@ -15,10 +15,17 @@ int main() {
 
   static constexpr auto i = 42;
 
-  "tmp"_test = [] {
-    expect(constant<42_i == i> and type<void> == type<void> and
-           type<list<void, int>> == type<list<void, int>>);
+  "type"_test= [] {
+    constexpr auto return_int = [] { return i; };
 
     expect(type<>(i) == type<int>);
+    expect(type<int> == type<>(i));
+    expect(type<int> == return_int());
+    expect(type<float> != return_int());
+  };
+
+  "constant"_test = [] {
+    expect(constant<42_i == i> and type<void> == type<void> and
+           type<list<void, int>> == type<list<void, int>>);
   };
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -547,7 +547,8 @@ template <class T>
 template <class T>
 struct type_ : op {
   template <class TOther>
-  [[nodiscard]] constexpr auto operator()(TOther) const -> const type_<TOther> {
+  [[nodiscard]] constexpr auto operator()(const TOther&) const
+      -> const type_<TOther> {
     return {};
   }
   [[nodiscard]] constexpr auto operator==(type_<T>) -> bool { return true; }
@@ -555,10 +556,18 @@ struct type_ : op {
   [[nodiscard]] constexpr auto operator==(type_<TOther>) -> bool {
     return false;
   }
+  template <class TOther>
+  [[nodiscard]] constexpr auto operator==(const TOther&) -> bool {
+    return std::is_same_v<TOther, T>;
+  }
   [[nodiscard]] constexpr auto operator!=(type_<T>) -> bool { return true; }
   template <class TOther>
   [[nodiscard]] constexpr auto operator!=(type_<TOther>) -> bool {
     return true;
+  }
+  template <class TOther>
+  [[nodiscard]] constexpr auto operator!=(const TOther&) -> bool {
+    return not std::is_same_v<TOther, T>;
   }
 };
 

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -465,6 +465,13 @@ int main() {
     }
 
     {
+      constexpr auto return_int = []() -> int { return {}; };
+      static_assert(type<int> == return_int());
+      static_assert(type<float> != return_int());
+      static_assert(type<const int&> != return_int());
+      static_assert(type<int&> != return_int());
+      static_assert(type<int*> != return_int());
+      static_assert(type<double> != return_int());
       static_assert(type<int> == type<int>);
       static_assert(type<void> == type<void>);
       static_assert(type<void*> == type<void*>);


### PR DESCRIPTION
Problem:
- There is no easy way to compare type of function result.

Solution:
- Add support for `type<int> == f()` comparison.