### PR TITLE
:bug: [UT] The header <ciso646> was removed in C++20, Fix #473

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2020 Kris Jusiak (kris at jusiak dot net)
+// Copyright (c) 2019-2021 Kris Jusiak (kris at jusiak dot net)
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
@@ -12,8 +12,8 @@ export import std;
 #pragma once
 #endif
 
-#if defined(_MSC_VER)
-#include <ciso646>  // and, or, not
+#if __has_include(<ios646.h>)
+#include <iso646.h>  // and, or, not, ...
 #endif
 
 #if not defined(__cpp_rvalue_references)
@@ -71,14 +71,9 @@ export import std;
 #endif
 
 #if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
-export namespace boost::inline ext::ut {
-#else
-namespace boost {
-inline namespace ext {
-namespace ut {
+export
 #endif
-
-inline namespace v1_1_8 {
+namespace boost::inline ext::ut::inline v1_1_8 {
 namespace utility {
 template <class>
 class function;
@@ -2329,10 +2324,5 @@ using operators::operator not;
 using operators::operator|;
 using operators::operator/;
 using operators::operator>>;
-}  // namespace v1_1_8
-}  // namespace ut
-#if !defined(__cpp_modules) || defined(BOOST_UT_DISABLE_MODULE)
-}  // namespace inline ext
-}  // namespace boost
-#endif
+}  // namespace boost::ext::ut::v1_1_8
 #endif


### PR DESCRIPTION
Problem:
- The code does not compile in MSVC 2022 (19.30.30528) because <ciso646>
  has been removed from C++20 - https://en.cppreference.com/w/cpp/header/ciso646.
  The header is required to provide and/or/not/... operator spellings
  alternatives.

Solution:
- Include <iso646.h> instead but only if the header is available.