### PR TITLE
:bug: fix gherkin lexical_cast for string input parameters

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2203,7 +2203,11 @@ class steps {
       T t{};
       std::istringstream iss{};
       iss.str(str);
-      iss >> t;
+      if constexpr (std::is_same_v<T, std::string>) {
+        t = iss.str();
+      } else {
+        iss >> t;
+      }
       return t;
     }
 


### PR DESCRIPTION
Problem:
- when a string parameter is parsed in a gherkin test clause, ut is ignoring
everything after the first whitespace character

Solution:
- introduce a special case for std::string in the lexical_cast
  method of gherkin test not to rely on the streaming input operator
  (works only until the first whitespace) but to take the whole value.