### PR TITLE
Fix Apple Clang 13 compilation error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run clang-tidy
         shell: bash
         run: |
-          export PATH=/usr/local/opt/llvm/bin/:${PATH}
-          /usr/local/opt/llvm/share/clang/run-clang-tidy.py \
+          export PATH=$(brew --prefix llvm)/bin:${PATH}
+          $(brew --prefix llvm)/bin/run-clang-tidy \
             -p build test 2>&1 | tee .run-clang-tidy.log
           builddriver cat .run-clang-tidy.log

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -237,6 +237,8 @@ template <class T>
   return {&__FUNCSIG__[120], sizeof(__FUNCSIG__) - 128};
 #elif defined(__clang_analyzer__)
   return {&__PRETTY_FUNCTION__[57], sizeof(__PRETTY_FUNCTION__) - 59};
+#elif defined(__clang__) and (__clang_major__ >= 13) and defined(__APPLE__)
+  return {&__PRETTY_FUNCTION__[57], sizeof(__PRETTY_FUNCTION__) - 59};
 #elif defined(__clang__) and (__clang_major__ >= 12) and not defined(__APPLE__)
   return {&__PRETTY_FUNCTION__[57], sizeof(__PRETTY_FUNCTION__) - 59};
 #elif defined(__clang__)


### PR DESCRIPTION
Problem:
-
Compiler: Apple Clang 13

1.
```
error: array index 70 is past the end of the array (which contains 62 elements) [-Werror,-Warray-bounds]
  return {&__PRETTY_FUNCTION__[70], sizeof(__PRETTY_FUNCTION__) - 72};
```

2.
`llvm/share/clang/run-clang-tidy.py` -> `llvm/bin/run-clang-tidy`

Solution:
-
1. Apply the same rule that is used for Clang 12.
2. Update new path for run-clang-tidy