### PR TITLE
Avoid exporting compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,62 +61,6 @@ else()
   target_compile_features(ut INTERFACE cxx_std_17)
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  if(WIN32) # clang-cl
-    # FIXME: we should not export this pedantic options! CK
-    target_compile_options(
-      ut
-      INTERFACE -Wall
-                -Wextra
-                # FIXME -Werror
-                -Wno-c++98-c++11-c++14-c++17-compat-pedantic
-                -Wno-c++98-c++11-compat
-                -Wno-c++98-compat
-                -Wno-c++98-compat-pedantic
-                -Wno-c99-extensions
-                -Wno-pedantic
-    )
-  else()
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-  endif()
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  # FIXME: we should not export this pedantic options! CK
-  target_compile_options(
-    ut
-    INTERFACE -Wall
-              -Wextra
-              # TODO: why not simpply -Wpedantic
-              -Werror
-              -Wcast-align
-              #-Wcast-align=strict
-              -Wcast-qual
-              -Wdouble-promotion
-              -Wduplicated-branches
-              -Wduplicated-cond
-              -Wlogical-op
-              -Wmissing-declarations
-              -Wmissing-include-dirs
-              -Wnull-dereference
-              -Wold-style-cast
-              -Wpointer-arith
-              -Wredundant-decls
-              -Wsign-conversion
-              -Wswitch-enum
-              -Wtrampolines
-              -Wunused-but-set-variable
-              -Wunused-result
-              -Wuseless-cast
-              -Wzero-as-null-pointer-constant
-              # FIXME
-              -Wno-undef
-              -Wno-missing-declarations
-              -Wno-sign-conversion
-              -Wno-float-equal
-  )
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  add_compile_options(/W4 /WX)
-endif()
-
 add_custom_target(style)
 add_custom_command(
   TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include

--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -1,5 +1,57 @@
 option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" ON)
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  if(WIN32) # clang-cl
+    set(BOOST_UT_COMPILE_OPTIONS
+      -Wall
+      -Wextra
+      # FIXME -Werror
+      -Wno-c++98-c++11-c++14-c++17-compat-pedantic
+      -Wno-c++98-c++11-compat
+      -Wno-c++98-compat
+      -Wno-c++98-compat-pedantic
+      -Wno-c99-extensions
+      -Wno-pedantic
+    )
+  else()
+    set(BOOST_UT_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Werror)
+  endif()
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+  set(BOOST_UT_COMPILE_OPTIONS
+    -Wall
+    -Wextra
+    # TODO: why not simpply -Wpedantic
+    -Werror
+    -Wcast-align
+    #-Wcast-align=strict
+    -Wcast-qual
+    -Wdouble-promotion
+    -Wduplicated-branches
+    -Wduplicated-cond
+    -Wlogical-op
+    -Wmissing-declarations
+    -Wmissing-include-dirs
+    -Wnull-dereference
+    -Wold-style-cast
+    -Wpointer-arith
+    -Wredundant-decls
+    -Wsign-conversion
+    -Wswitch-enum
+    -Wtrampolines
+    -Wunused-but-set-variable
+    -Wunused-result
+    -Wuseless-cast
+    -Wzero-as-null-pointer-constant
+    # FIXME
+    -Wno-undef
+    -Wno-missing-declarations
+    -Wno-sign-conversion
+    -Wno-float-equal
+  )
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(BOOST_UT_COMPILE_OPTIONS /W4 /WX)
+endif()
+
 function(ut_add_custom_command_or_test)
   # Define the supported set of keywords
   set(prefix "PARSE")
@@ -11,6 +63,7 @@ function(ut_add_custom_command_or_test)
   include(CMakeParseArguments)
   cmake_parse_arguments("${prefix}" "${noValues}" "${singleValues}" "${multiValues}" ${ARGN})
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
+  target_compile_options(${PARSE_TARGET} PRIVATE ${BOOST_UT_COMPILE_OPTIONS})
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
     add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})


### PR DESCRIPTION
Problem:
- The ut (aliased as Boost::ut) target exports compile options as `INTERFACE`, but it mostly does not need. (this is also pointed out as [`FIXME`](https://github.com/boost-ext/ut/blob/67b136c0267a54248d05fcba63905ff5e6abf0b7/CMakeLists.txt#L66))
- However, it seems that tests, examples, and benchmarks want to use the options.

Solution:
- Delete compile options for the interface `ut`.
- Add compile options for targets of tests, examples, and benchmarks as `PRIVATE`.

Issue: #

Reviewers:
@
