### PR TITLE
Update Windows CI CMake Visual Studio generator

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: configure
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -G "Visual Studio 16 2019" -T ClangCL
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -G "Visual Studio 17 2022" -T ClangCL
 
       - name: build
         run: cmake --build build --config Debug -j4


### PR DESCRIPTION

Problem:
- Windows CI failing on master branch.
- GH Actions windows-latest defaults to 2022 image which includes VS 2022 instead of VS 2019.

Solution:
- Update the Windows CI to use VS 2022 generator now.

Issue: #

Reviewers:
@krzysztof-jusiak 
