### PR TITLE
Add documentation for `reflection::type_name<T>()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,11 +898,10 @@ All tests passed (14 asserts in 10 tests)
 ```
 
 > https://godbolt.org/z/4xGGdo
-</p>
+
   
-<p>
-If you need to know the specific type for which the test failed,
-you can use `reflection::type_name<T>()`:
+> And whenever I need to know the specific type for which the test failed,
+> I can use `reflection::type_name<T>()`, like this:
   
 ```cpp
 "types with type name"_test =

--- a/README.md
+++ b/README.md
@@ -898,6 +898,28 @@ All tests passed (14 asserts in 10 tests)
 ```
 
 > https://godbolt.org/z/4xGGdo
+</p>
+  
+<p>
+If you need to know the specific type for which the test failed,
+you can use `reflection::type_name<T>()`:
+  
+```cpp
+"types with type name"_test =
+    []<class T>() {
+      expect(std::is_unsigned_v<T>) << reflection::type_name<T>() << "is unsigned";
+    }
+  | std::tuple<unsigned int, float>{};
+```
+
+```
+Running "types with type name"...PASSED
+Running "types with type name"...
+  <source>:10:FAILED [false] float is unsigned
+FAILED
+```
+  
+> https://godbolt.org/z/MEnGnbTY4
 
 </p>
 </details>


### PR DESCRIPTION
Problem:
- there exists a way to print the name of a type in templated tests, but it was not documented

Solution:
- added a small section beneath the _parameterized_ example

I tried to mimic the existing first-person style of writing. If that is not desired, I can revert the last commit.

Issue: #500

Reviewers:
@krzysztof-jusiak 
