### PR TITLE
exclude any printable type from the container print overload

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -374,8 +374,8 @@ static constexpr auto is_container_v =
     is_valid<T>([](auto t) -> decltype(t.begin(), t.end(), void()) {});
 
 template <class T>
-static constexpr auto has_npos_v =
-    is_valid<T>([](auto t) -> decltype(void(t.npos)) {});
+static constexpr auto has_user_print =
+    is_valid<T>([](auto t) -> decltype(void(declval<std::ostringstream>() << t)) {});
 
 template <class T>
 static constexpr auto has_value_v =
@@ -952,8 +952,8 @@ class printer {
   }
 
   template <class T,
-            type_traits::requires_t<type_traits::is_container_v<T> and
-                                    not type_traits::has_npos_v<T>> = 0>
+            type_traits::requires_t<not type_traits::has_user_print<T> and
+                                    type_traits::is_container_v<T>> = 0>
   auto& operator<<(T&& t) {
     *this << '{';
     auto first = true;
@@ -1064,7 +1064,7 @@ class printer {
 
  private:
   ut::colors colors_{};
-  std::stringstream out_{};
+  std::ostringstream out_{};
 };
 
 template <class TPrinter = printer>


### PR DESCRIPTION
Problem:

Currently, for container data types, the output is overloaded in the form `{element, ...}`. A container datatype is recognized if it has `begin()` and `end()` function members. The overloading excludes data types that have a public member `npos`. This probably refers to `string` and `string_view`.

This will override any user data type output that may have been defined! (E.g. multidimensional arrays.)

Solution:

- Replace string-like detection with output operator detection
- (Note: I also replaced `std::stringstream` by `std::ostringstream`.)

Issue: #493

Reviewers:
