### PR TITLE
Remove use of std::numbers in unit tests

### DIFF
--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1000,7 +1000,7 @@ int main() {
       test_assert("42 ~ (43 +/- 2)" == test_cfg.assertion_calls[0].expr);
       test_assert(test_cfg.assertion_calls[0].result);
 
-      expect(near(3.141592654, std::numbers::pi_v<double>, 1e-9));
+      expect(near(3.141592654, 3.1415926536, 1e-9));
       test_assert(2 == std::size(test_cfg.assertion_calls));
       test_assert("3.14159 ~ (3.14159 +/- 1e-09)" ==
                   test_cfg.assertion_calls[1].expr);


### PR DESCRIPTION
The standard numbers module/header is not explicitly imported/included, and its facilities are not strictly necessary for the test that used it. This fixes an unexpected build automation failure.

Problem:
A recently added unit test for `near()` used `std::numbers::pi_v<double>` even though the `numbers` module/header is not imported/included in `ut.cpp`.

Solution:
Replace `std::numbers::pi_v<double>` in the unit test with a literal `3.1415926536`.

Issue: #509

Reviewers:
None (yet!)
