### PR TITLE
Rename near() to approx()

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -683,9 +683,9 @@ struct eq_ : op {
 };
 
 template <class TLhs, class TRhs, class TEpsilon>
-struct near_ : op {
-  constexpr near_(const TLhs& lhs = {}, const TRhs& rhs = {},
-                  const TEpsilon& epsilon = {})
+struct approx_ : op {
+  constexpr approx_(const TLhs& lhs = {}, const TRhs& rhs = {},
+                    const TEpsilon& epsilon = {})
       : lhs_{lhs}, rhs_{rhs}, epsilon_{epsilon}, value_{[&] {
           using std::operator<;
 
@@ -1010,7 +1010,7 @@ class printer {
   }
 
   template <class TLhs, class TRhs, class TEpsilon>
-  auto& operator<<(const detail::near_<TLhs, TRhs, TEpsilon>& op) {
+  auto& operator<<(const detail::approx_<TLhs, TRhs, TEpsilon>& op) {
     return (*this << color(op) << op.lhs() << " ~ (" << op.rhs() << " +/- "
                   << op.epsilon() << ')' << colors_.none);
   }
@@ -2209,9 +2209,9 @@ template <class TLhs, class TRhs>
   return detail::eq_{lhs, rhs};
 }
 template <class TLhs, class TRhs, class TEpsilon>
-[[nodiscard]] constexpr auto near(const TLhs& lhs, const TRhs& rhs,
-                                  const TEpsilon& epsilon) {
-  return detail::near_{lhs, rhs, epsilon};
+[[nodiscard]] constexpr auto approx(const TLhs& lhs, const TRhs& rhs,
+                                    const TEpsilon& epsilon) {
+  return detail::approx_{lhs, rhs, epsilon};
 }
 template <class TLhs, class TRhs>
 [[nodiscard]] constexpr auto neq(const TLhs& lhs, const TRhs& rhs) {

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -995,18 +995,18 @@ int main() {
     {
       test_cfg = fake_cfg{};
 
-      expect(near(42_i, 43_i, 2_i));
+      expect(approx(42_i, 43_i, 2_i));
       test_assert(1 == std::size(test_cfg.assertion_calls));
       test_assert("42 ~ (43 +/- 2)" == test_cfg.assertion_calls[0].expr);
       test_assert(test_cfg.assertion_calls[0].result);
 
-      expect(near(3.141592654, std::numbers::pi_v<double>, 1e-9));
+      expect(approx(3.141592654, std::numbers::pi_v<double>, 1e-9));
       test_assert(2 == std::size(test_cfg.assertion_calls));
       test_assert("3.14159 ~ (3.14159 +/- 1e-09)" ==
                   test_cfg.assertion_calls[1].expr);
       test_assert(test_cfg.assertion_calls[1].result);
 
-      expect(near(1_u, 2_u, 3_u));
+      expect(approx(1_u, 2_u, 3_u));
       test_assert(3 == std::size(test_cfg.assertion_calls));
       test_assert("1 ~ (2 +/- 3)" == test_cfg.assertion_calls[2].expr);
       test_assert(test_cfg.assertion_calls[2].result);


### PR DESCRIPTION
Problem:
- `near` is commonly `#define`d by many platforms (e.g., `#include <Windows.h>`), so `#include`-ing `ut.hpp` causes some weird compilation errors with the definition of `near()`.

Solution:
- Rename `near()` to `approx()`.
- Note that requiring a particular `#include` order would also suffice, but it puts undue burden on the user. This isn't to say that this problem is completely prevented, however, as it's possible to `#define` anything into oblivion.

Issue: #511

Reviewers:
None
