### PR TITLE
Fix all compilation errors at once.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -380,8 +380,8 @@ static constexpr auto is_container_v =
     is_valid<T>([](auto t) -> decltype(t.begin(), t.end(), void()) {});
 
 template <class T>
-static constexpr auto has_user_print =
-    is_valid<T>([](auto t) -> decltype(void(declval<std::ostringstream>() << t)) {});
+static constexpr auto has_user_print = is_valid<T>(
+    [](auto t) -> decltype(void(declval<std::ostringstream&>() << t)) {});
 
 template <class T>
 static constexpr auto has_value_v =
@@ -683,9 +683,9 @@ struct eq_ : op {
 };
 
 template <class TLhs, class TRhs, class TEpsilon>
-struct near_ : op {
-  constexpr near_(const TLhs& lhs = {}, const TRhs& rhs = {},
-                  const TEpsilon& epsilon = {})
+struct approx_ : op {
+  constexpr approx_(const TLhs& lhs = {}, const TRhs& rhs = {},
+                    const TEpsilon& epsilon = {})
       : lhs_{lhs}, rhs_{rhs}, epsilon_{epsilon}, value_{[&] {
           using std::operator<;
 
@@ -1010,7 +1010,7 @@ class printer {
   }
 
   template <class TLhs, class TRhs, class TEpsilon>
-  auto& operator<<(const detail::near_<TLhs, TRhs, TEpsilon>& op) {
+  auto& operator<<(const detail::approx_<TLhs, TRhs, TEpsilon>& op) {
     return (*this << color(op) << op.lhs() << " ~ (" << op.rhs() << " +/- "
                   << op.epsilon() << ')' << colors_.none);
   }
@@ -2209,9 +2209,9 @@ template <class TLhs, class TRhs>
   return detail::eq_{lhs, rhs};
 }
 template <class TLhs, class TRhs, class TEpsilon>
-[[nodiscard]] constexpr auto near(const TLhs& lhs, const TRhs& rhs,
-                                  const TEpsilon& epsilon) {
-  return detail::near_{lhs, rhs, epsilon};
+[[nodiscard]] constexpr auto approx(const TLhs& lhs, const TRhs& rhs,
+                                    const TEpsilon& epsilon) {
+  return detail::approx_{lhs, rhs, epsilon};
 }
 template <class TLhs, class TRhs>
 [[nodiscard]] constexpr auto neq(const TLhs& lhs, const TRhs& rhs) {

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -27,3 +27,6 @@ else()
 endif()
 
 ut(ut)
+if(WIN32)
+  ut(win_compat_test)
+endif()

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -253,14 +253,16 @@ struct custom {
   }
 };
 
-struct custom_vec: std::vector<int> {
+struct custom_vec : std::vector<int> {
   using std::vector<int>::vector;
 
-  friend auto operator<<(std::ostream& os, const custom_vec& c) -> std::ostream& {
+  friend auto operator<<(std::ostream& os, const custom_vec& c)
+      -> std::ostream& {
     os << "custom_vec{";
-    if(!c.empty()){
+    if (!c.empty()) {
       os << c.front();
-      std::for_each(std::next(c.begin()), c.end(), [&os](int const v){ os << ", " << v; });
+      std::for_each(std::next(c.begin()), c.end(),
+                    [&os](int const v) { os << ", " << v; });
     }
     os << '}';
     return os;
@@ -996,18 +998,18 @@ int main() {
     {
       test_cfg = fake_cfg{};
 
-      expect(near(42_i, 43_i, 2_i));
+      expect(approx(42_i, 43_i, 2_i));
       test_assert(1 == std::size(test_cfg.assertion_calls));
       test_assert("42 ~ (43 +/- 2)" == test_cfg.assertion_calls[0].expr);
       test_assert(test_cfg.assertion_calls[0].result);
 
-      expect(near(3.141592654, std::numbers::pi_v<double>, 1e-9));
+      expect(approx(3.141592654, 3.1415926536, 1e-9));
       test_assert(2 == std::size(test_cfg.assertion_calls));
       test_assert("3.14159 ~ (3.14159 +/- 1e-09)" ==
                   test_cfg.assertion_calls[1].expr);
       test_assert(test_cfg.assertion_calls[1].result);
 
-      expect(near(1_u, 2_u, 3_u));
+      expect(approx(1_u, 2_u, 3_u));
       test_assert(3 == std::size(test_cfg.assertion_calls));
       test_assert("1 ~ (2 +/- 3)" == test_cfg.assertion_calls[2].expr);
       test_assert(test_cfg.assertion_calls[2].result);
@@ -1145,11 +1147,12 @@ int main() {
       test_assert(2 == std::size(test_cfg.assertion_calls));
 
       test_assert(test_cfg.assertion_calls[0].result);
-      test_assert("custom_vec{42, 5} == custom_vec{42, 5}" == test_cfg.assertion_calls[0].expr);
+      test_assert("custom_vec{42, 5} == custom_vec{42, 5}" ==
+                  test_cfg.assertion_calls[0].expr);
 
       test_assert(test_cfg.assertion_calls[1].result);
-      test_assert("custom_vec{42, 5, 3} != custom_vec{42, 5, 6}" == test_cfg.assertion_calls[1].expr);
-
+      test_assert("custom_vec{42, 5, 3} != custom_vec{42, 5, 6}" ==
+                  test_cfg.assertion_calls[1].expr);
     }
 
     {

--- a/test/ut/win_compat_test.cpp
+++ b/test/ut/win_compat_test.cpp
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2019-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// ensure no conflict between `Windows.h` and `ut.hpp`
+#include <Windows.h>
+
+#include "boost/ut.hpp"
+
+namespace ut = boost::ut;
+
+int main() {
+  using namespace ut;
+  expect(true);
+
+  return 0;
+}


### PR DESCRIPTION
Problem:
- clang-tidy failed to evaluate `declval<std::ostringstream>() << t`
- `std::numbers::pi_v` is a C++20 feature.
- `near` conflicts with Macro `near` defined in `<Windows.h>`

Solution:
- Use `declval<std::ostringstream&>() << t` instead.
- Remove use of `std::numbers::pi_v` since minimum support standard is C++17.
- Change `near` to `approx`.

Additional:
- Add `win_compat_test.cpp` to ensure no conflict with `<Windows.h>`
- Apply clang-format.

Issue: #509 #511 

Reviewers:
@krzysztof-jusiak 
