### PR TITLE
Fix issue #468 type inequality operator returns true

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -565,7 +565,7 @@ struct type_ : op {
   [[nodiscard]] constexpr auto operator==(const TOther&) -> bool {
     return std::is_same_v<TOther, T>;
   }
-  [[nodiscard]] constexpr auto operator!=(type_<T>) -> bool { return true; }
+  [[nodiscard]] constexpr auto operator!=(type_<T>) -> bool { return false; }
   template <class TOther>
   [[nodiscard]] constexpr auto operator!=(type_<TOther>) -> bool {
     return true;

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -516,6 +516,7 @@ int main() {
       static_assert(type<int*> != return_int());
       static_assert(type<double> != return_int());
       static_assert(type<int> == type<int>);
+      static_assert(!(type<int> != type<int>));
       static_assert(type<void> == type<void>);
       static_assert(type<void*> == type<void*>);
       static_assert(type<int> != type<const int>);


### PR DESCRIPTION
Change type<T>::operator!=(type<T>) to return false.

Add a single test line to test/ut/ut.cpp:

  static_assert(!(type<int> != type<int>));

Problem:
`type<T>::operator!=(type<T>)` returns `true`

Solution:
change `true` return to `false`

Issue: #468

Reviewers:
@krzysztof-jusiak
