### PR TITLE
Make `ut` compiled by MSVC v143 toolset.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,13 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix: 
+        toolset: [ClangCl, v143]
+        std: [17, 20]
+        exclude:
+          - toolset: v143
+            std: 17
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +36,7 @@ jobs:
 
       - name: configure
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -G "Visual Studio 17 2022" -T ClangCL
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -DBOOST_UT_DISABLE_MODULE=ON -G "Visual Studio 17 2022" -T ${{matrix.toolset}} -DCMAKE_CXX_STANDARD:STRING=${{matrix.std}}
 
       - name: build
         run: cmake --build build --config Debug -j4

--- a/example/expect.cpp
+++ b/example/expect.cpp
@@ -71,7 +71,7 @@ int main() {
     expect(type<int> == type<int>);
     expect(type<float> != type<double>);
 
-    const auto i = 0;
+    [[maybe_unused]] const auto i = 0;
     expect(type<const int> == type<decltype(i)>);
     expect(type<decltype(i)> != type<int>);
   };

--- a/example/parameterized.cpp
+++ b/example/parameterized.cpp
@@ -33,7 +33,7 @@ int main() {
 
   /// Language syntax
   std::apply(
-      [](auto... args) {
+      []([[maybe_unused]] auto... args) {
         ((test("args and types / " + std::to_string(args)) =
               [&] {
                 using TArgs = decltype(args);

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -276,7 +276,7 @@ template <class T, char... Cs>
   static_assert(
       ((Cs == '.' or Cs == '\'' or (Cs >= '0' and Cs <= '9')) and ...));
   T result{};
-  for (const char c : {Cs...}) {
+  for (const char c : std::array{Cs...}) {
     if (c == '.') {
       break;
     }
@@ -1919,9 +1919,9 @@ inline auto operator>>(const T& t,
                        const detail::value_location<detail::fatal>&) {
   using fatal_t = detail::fatal_<T>;
   struct fatal_ : fatal_t, detail::log {
-    using type [[maybe_unused]] = fatal_t;
+    using type = fatal_t;
     using fatal_t::fatal_t;
-    const detail::terse_<fatal_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return fatal_{t};
 }
@@ -1931,9 +1931,9 @@ constexpr auto operator==(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using eq_t = detail::eq_<T, detail::value_location<typename T::value_type>>;
   struct eq_ : eq_t, detail::log {
-    using type [[maybe_unused]] = eq_t;
+    using type = eq_t;
     using eq_t::eq_t;
-    const detail::terse_<eq_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return eq_{lhs, rhs};
 }
@@ -1943,9 +1943,9 @@ constexpr auto operator==(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using eq_t = detail::eq_<detail::value_location<typename T::value_type>, T>;
   struct eq_ : eq_t, detail::log {
-    using type [[maybe_unused]] = eq_t;
+    using type = eq_t;
     using eq_t::eq_t;
-    const detail::terse_<eq_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return eq_{lhs, rhs};
 }
@@ -1955,9 +1955,9 @@ constexpr auto operator!=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using neq_t = detail::neq_<T, detail::value_location<typename T::value_type>>;
   struct neq_ : neq_t, detail::log {
-    using type [[maybe_unused]] = neq_t;
+    using type = neq_t;
     using neq_t::neq_t;
-    const detail::terse_<neq_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return neq_{lhs, rhs};
 }
@@ -1967,9 +1967,9 @@ constexpr auto operator!=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using neq_t = detail::neq_<detail::value_location<typename T::value_type>, T>;
   struct neq_ : neq_t {
-    using type [[maybe_unused]] = neq_t;
+    using type = neq_t;
     using neq_t::neq_t;
-    const detail::terse_<neq_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return neq_{lhs, rhs};
 }
@@ -1979,9 +1979,9 @@ constexpr auto operator>(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using gt_t = detail::gt_<T, detail::value_location<typename T::value_type>>;
   struct gt_ : gt_t, detail::log {
-    using type [[maybe_unused]] = gt_t;
+    using type = gt_t;
     using gt_t::gt_t;
-    const detail::terse_<gt_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return gt_{lhs, rhs};
 }
@@ -1991,9 +1991,9 @@ constexpr auto operator>(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using gt_t = detail::gt_<detail::value_location<typename T::value_type>, T>;
   struct gt_ : gt_t, detail::log {
-    using type [[maybe_unused]] = gt_t;
+    using type = gt_t;
     using gt_t::gt_t;
-    const detail::terse_<gt_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return gt_{lhs, rhs};
 }
@@ -2003,9 +2003,9 @@ constexpr auto operator>=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using ge_t = detail::ge_<T, detail::value_location<typename T::value_type>>;
   struct ge_ : ge_t, detail::log {
-    using type [[maybe_unused]] = ge_t;
+    using type = ge_t;
     using ge_t::ge_t;
-    const detail::terse_<ge_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return ge_{lhs, rhs};
 }
@@ -2015,9 +2015,9 @@ constexpr auto operator>=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using ge_t = detail::ge_<detail::value_location<typename T::value_type>, T>;
   struct ge_ : ge_t, detail::log {
-    using type [[maybe_unused]] = ge_t;
+    using type = ge_t;
     using ge_t::ge_t;
-    const detail::terse_<ge_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return ge_{lhs, rhs};
 }
@@ -2027,9 +2027,9 @@ constexpr auto operator<(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using lt_t = detail::lt_<T, detail::value_location<typename T::value_type>>;
   struct lt_ : lt_t, detail::log {
-    using type [[maybe_unused]] = lt_t;
+    using type = lt_t;
     using lt_t::lt_t;
-    const detail::terse_<lt_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return lt_{lhs, rhs};
 }
@@ -2039,9 +2039,9 @@ constexpr auto operator<(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using lt_t = detail::lt_<detail::value_location<typename T::value_type>, T>;
   struct lt_ : lt_t, detail::log {
-    using type [[maybe_unused]] = lt_t;
+    using type = lt_t;
     using lt_t::lt_t;
-    const detail::terse_<lt_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return lt_{lhs, rhs};
 }
@@ -2051,9 +2051,9 @@ constexpr auto operator<=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using le_t = detail::le_<T, detail::value_location<typename T::value_type>>;
   struct le_ : le_t, detail::log {
-    using type [[maybe_unused]] = le_t;
+    using type = le_t;
     using le_t::le_t;
-    const detail::terse_<le_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return le_{lhs, rhs};
 }
@@ -2063,9 +2063,9 @@ constexpr auto operator<=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using le_t = detail::le_<detail::value_location<typename T::value_type>, T>;
   struct le_ : le_t {
-    using type [[maybe_unused]] = le_t;
+    using type = le_t;
     using le_t::le_t;
-    const detail::terse_<le_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return le_{lhs, rhs};
 }
@@ -2076,9 +2076,9 @@ template <class TLhs, class TRhs,
 constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
   using and_t = detail::and_<typename TLhs::type, typename TRhs::type>;
   struct and_ : and_t, detail::log {
-    using type [[maybe_unused]] = and_t;
+    using type = and_t;
     using and_t::and_t;
-    const detail::terse_<and_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return and_{lhs, rhs};
 }
@@ -2089,9 +2089,9 @@ template <class TLhs, class TRhs,
 constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
   using or_t = detail::or_<typename TLhs::type, typename TRhs::type>;
   struct or_ : or_t, detail::log {
-    using type [[maybe_unused]] = or_t;
+    using type = or_t;
     using or_t::or_t;
-    const detail::terse_<or_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return or_{lhs, rhs};
 }
@@ -2100,9 +2100,9 @@ template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
 constexpr auto operator not(const T& t) {
   using not_t = detail::not_<typename T::type>;
   struct not_ : not_t, detail::log {
-    using type [[maybe_unused]] = not_t;
+    using type = not_t;
     using not_t::not_t;
-    const detail::terse_<not_t> _{*this};
+    const detail::terse_<type> _{*this};
   };
   return not_{t};
 }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -536,13 +536,9 @@ int main() {
       reporter.on(events::test_begin{});
       reporter.on(events::test_run{});
       reporter.on(events::assertion_pass<bool>{
-          .expr = true,
-          .location =
-              reflection::source_location::current("file/name.cpp", 42)});
+          .expr = true, .location = reflection::source_location::current()});
       reporter.on(events::assertion_fail<bool>{
-          .expr = false,
-          .location =
-              reflection::source_location::current("file/name.cpp", 42)});
+          .expr = false, .location = reflection::source_location::current()});
       reporter.on(events::fatal_assertion{});
       reporter.on(events::test_end{});
 


### PR DESCRIPTION
Problem:
- `ut` can only be compiled by MSVC w/ clang-cl on Windows.

Solution:
- Make `ut` to be compiled by MSVC w/ v143 toolset as well.
- Update Windows CI to build code with MSVC v143 toolset as well. (Not build with module support cuz it's broken...)

Reviewers:
@krzysztof-jusiak 
