### PR TITLE
Fix `has_value_v` and `has_epsilon_v` not being restrictive enough.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -383,13 +383,31 @@ template <class T>
 static constexpr auto has_user_print = is_valid<T>(
     [](auto t) -> decltype(void(declval<std::ostringstream&>() << t)) {});
 
-template <class T>
-static constexpr auto has_value_v =
-    is_valid<T>([](auto t) -> decltype(void(t.value)) {});
+template <class T, class = void>
+struct has_static_member_object_value : std::false_type {};
 
 template <class T>
-static constexpr auto has_epsilon_v =
-    is_valid<T>([](auto t) -> decltype(void(t.epsilon)) {});
+struct has_static_member_object_value<T,
+                                      std::void_t<decltype(declval<T>().value)>>
+    : std::bool_constant<!std::is_member_pointer_v<decltype(&T::value)> &&
+                         !std::is_function_v<decltype(T::value)>> {};
+
+template <class T>
+inline constexpr bool has_static_member_object_value_v =
+    has_static_member_object_value<T>::value;
+
+template <class T, class = void>
+struct has_static_member_object_epsilon : std::false_type {};
+
+template <class T>
+struct has_static_member_object_epsilon<
+    T, std::void_t<decltype(declval<T>().epsilon)>>
+    : std::bool_constant<!std::is_member_pointer_v<decltype(&T::epsilon)> &&
+                         !std::is_function_v<decltype(T::epsilon)>> {};
+
+template <class T>
+inline constexpr bool has_static_member_object_epsilon_v =
+    has_static_member_object_epsilon<T>::value;
 
 template <class T>
 inline constexpr auto is_floating_point_v = false;
@@ -657,16 +675,20 @@ struct eq_ : op {
           using std::operator==;
           using std::operator<;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value == TRhs::value;
-          } else if constexpr (type_traits::has_epsilon_v<TLhs> and
-                               type_traits::has_epsilon_v<TRhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TLhs> and
+                               type_traits::has_static_member_object_epsilon_v<
+                                   TRhs>) {
             return math::abs(get(lhs) - get(rhs)) <
                    math::min_value(TLhs::epsilon, TRhs::epsilon);
-          } else if constexpr (type_traits::has_epsilon_v<TLhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TLhs>) {
             return math::abs(get(lhs) - get(rhs)) < TLhs::epsilon;
-          } else if constexpr (type_traits::has_epsilon_v<TRhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TRhs>) {
             return math::abs(get(lhs) - get(rhs)) < TRhs::epsilon;
           } else {
             return get(lhs) == get(rhs);
@@ -689,9 +711,10 @@ struct approx_ : op {
       : lhs_{lhs}, rhs_{rhs}, epsilon_{epsilon}, value_{[&] {
           using std::operator<;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs> and
-                        type_traits::has_value_v<TEpsilon>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs> and
+                        type_traits::has_static_member_object_value_v<
+                            TEpsilon>) {
             return math::abs_diff(TLhs::value, TRhs::value) < TEpsilon::value;
           } else {
             return math::abs_diff(get(lhs), get(rhs)) < get(epsilon);
@@ -717,16 +740,20 @@ struct neq_ : op {
           using std::operator!=;
           using std::operator>;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value != TRhs::value;
-          } else if constexpr (type_traits::has_epsilon_v<TLhs> and
-                               type_traits::has_epsilon_v<TRhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TLhs> and
+                               type_traits::has_static_member_object_epsilon_v<
+                                   TRhs>) {
             return math::abs(get(lhs_) - get(rhs_)) >
                    math::min_value(TLhs::epsilon, TRhs::epsilon);
-          } else if constexpr (type_traits::has_epsilon_v<TLhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TLhs>) {
             return math::abs(get(lhs_) - get(rhs_)) > TLhs::epsilon;
-          } else if constexpr (type_traits::has_epsilon_v<TRhs>) {
+          } else if constexpr (type_traits::has_static_member_object_epsilon_v<
+                                   TRhs>) {
             return math::abs(get(lhs_) - get(rhs_)) > TRhs::epsilon;
           } else {
             return get(lhs_) != get(rhs_);
@@ -748,8 +775,8 @@ struct gt_ : op {
       : lhs_{lhs}, rhs_{rhs}, value_{[&] {
           using std::operator>;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value > TRhs::value;
           } else {
             return get(lhs_) > get(rhs_);
@@ -771,8 +798,8 @@ struct ge_ : op {
       : lhs_{lhs}, rhs_{rhs}, value_{[&] {
           using std::operator>=;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value >= TRhs::value;
           } else {
             return get(lhs_) >= get(rhs_);
@@ -794,8 +821,8 @@ struct lt_ : op {
       : lhs_{lhs}, rhs_{rhs}, value_{[&] {
           using std::operator<;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value < TRhs::value;
           } else {
             return get(lhs_) < get(rhs_);
@@ -818,8 +845,8 @@ struct le_ : op {
       : lhs_{lhs}, rhs_{rhs}, value_{[&] {
           using std::operator<=;
 
-          if constexpr (type_traits::has_value_v<TLhs> and
-                        type_traits::has_value_v<TRhs>) {
+          if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
+                        type_traits::has_static_member_object_value_v<TRhs>) {
             return TLhs::value <= TRhs::value;
           } else {
             return get(lhs_) <= get(rhs_);

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -20,6 +20,58 @@
 
 namespace ut = boost::ut;
 
+namespace test_has_member_object {
+
+struct not_defined {};
+
+class private_member_object_value {
+  int value;
+
+ public:
+  private_member_object_value(int value) : value(value) {}
+};
+
+struct public_member_object_value {
+  int value;
+};
+
+struct public_static_member_object_value {
+  static int value;
+};
+
+struct public_member_function_value {
+  int value() const { return 0; }
+};
+
+struct public_static_member_function_value {
+  static int value() { return 0; }
+};
+
+class private_member_object_epsilon {
+  int epsilon;
+
+ public:
+  private_member_object_epsilon(int epsilon) : epsilon(epsilon) {}
+};
+
+struct public_member_object_epsilon {
+  int epsilon;
+};
+
+struct public_static_member_object_epsilon {
+  static int epsilon;
+};
+
+struct public_member_function_epsilon {
+  int epsilon() const { return 0; }
+};
+
+struct public_static_member_function_epsilon {
+  static int epsilon() { return 0; }
+};
+
+}  // namespace test_has_member_object
+
 constexpr auto to_string = [](const auto expr) {
   ut::printer printer{{.none = "", .pass = "", .fail = ""}};
   printer << std::boolalpha << expr;
@@ -293,6 +345,37 @@ int main() {
       static_assert(
           std::is_same_v<int,
                          type_traits::function_traits<int()>::result_type>);
+    }
+
+    {
+      static_assert(!type_traits::has_static_member_object_value_v<
+                    test_has_member_object::not_defined>);
+      static_assert(!type_traits::has_static_member_object_value_v<
+                    test_has_member_object::private_member_object_value>);
+      static_assert(!type_traits::has_static_member_object_value_v<
+                    test_has_member_object::public_member_object_value>);
+      static_assert(type_traits::has_static_member_object_value_v<
+                    test_has_member_object::public_static_member_object_value>);
+      static_assert(!type_traits::has_static_member_object_value_v<
+                    test_has_member_object::public_member_function_value>);
+      static_assert(
+          !type_traits::has_static_member_object_value_v<
+              test_has_member_object::public_static_member_function_value>);
+
+      static_assert(!type_traits::has_static_member_object_epsilon_v<
+                    test_has_member_object::not_defined>);
+      static_assert(!type_traits::has_static_member_object_epsilon_v<
+                    test_has_member_object::private_member_object_epsilon>);
+      static_assert(!type_traits::has_static_member_object_epsilon_v<
+                    test_has_member_object::public_member_object_epsilon>);
+      static_assert(
+          type_traits::has_static_member_object_epsilon_v<
+              test_has_member_object::public_static_member_object_epsilon>);
+      static_assert(!type_traits::has_static_member_object_epsilon_v<
+                    test_has_member_object::public_member_function_epsilon>);
+      static_assert(
+          !type_traits::has_static_member_object_epsilon_v<
+              test_has_member_object::public_static_member_function_epsilon>);
     }
 
     {


### PR DESCRIPTION
Problem:
- #505

Solution:
- Return true only if `value`/`epsilon` is ___public static member object___, otherwise (___not defined___/___private___/___non-static member object___/___static method___/___non-static method___) return false.
- Add tests to verify the fix.

Issue: #505 

Reviewers:
@krzysztof-jusiak @80Ltrumpet 
