### PR TITLE
cmake: allow user defined INCLUDE_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,9 @@ endif()
 
 add_library(ut INTERFACE)
 
-set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)
+if(NOT DEFINED INCLUDE_INSTALL_DIR)
+  set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)
+endif()
 # XXX variant: set(INCLUDE_INSTALL_DIR include)
 target_include_directories(ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>)
 if(APPLE)


### PR DESCRIPTION
Problem:
- Install path `include/ut-1.1.9/include/boost` is a bit messy for CMake to import `boost/ut.hpp` with CMake command `find_path`.

```cmake
find_path(ut_INCLUDE_DIR "ut-1.1.9/include/boost/ut.hpp" REQUIRED)

target_include_directories(main
PRIVATE
    "${ut_INCLUDE_DIR}/ut-1.1.9/include"
)
```

Users can use `Boost::ut` if they are familiar with the CMake. 
But it would be better if a more simplified use-case is also available.

Solution:
- When `INCLUDE_INSTALL_DIR` is provided, CMakeLists.txt will use the value.

```console
$ cmake -S . -B build -DINCLUDE_INSTALL_DIR="include"
...
$ cmake --build build --target install 
...
```

```cmake
find_path(ut_INCLUDE_DIR "boost/ut.hpp" REQUIRED)

target_include_directories(main
PRIVATE
    ${ut_INCLUDE_DIR}
)
```

