### PR TITLE
Call reporter summary handler once from runner

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1174,30 +1174,27 @@ class reporter {
   auto on(events::fatal_assertion) -> void {}
 
   auto on(events::summary) -> void {
-    if (static auto once = true; once) {
-      once = false;
-      if (tests_.fail or asserts_.fail) {
-        printer_ << "\n========================================================"
-                    "=======================\n"
-                 << "tests:   " << (tests_.pass + tests_.fail) << " | "
-                 << printer_.colors().fail << tests_.fail << " failed"
-                 << printer_.colors().none << '\n'
-                 << "asserts: " << (asserts_.pass + asserts_.fail) << " | "
-                 << asserts_.pass << " passed"
-                 << " | " << printer_.colors().fail << asserts_.fail
-                 << " failed" << printer_.colors().none << '\n';
-        std::cerr << printer_.str() << std::endl;
-      } else {
-        std::cout << printer_.colors().pass << "All tests passed"
-                  << printer_.colors().none << " (" << asserts_.pass
-                  << " asserts in " << tests_.pass << " tests)\n";
+    if (tests_.fail or asserts_.fail) {
+      printer_ << "\n========================================================"
+                  "=======================\n"
+               << "tests:   " << (tests_.pass + tests_.fail) << " | "
+               << printer_.colors().fail << tests_.fail << " failed"
+               << printer_.colors().none << '\n'
+               << "asserts: " << (asserts_.pass + asserts_.fail) << " | "
+               << asserts_.pass << " passed"
+               << " | " << printer_.colors().fail << asserts_.fail << " failed"
+               << printer_.colors().none << '\n';
+      std::cerr << printer_.str() << std::endl;
+    } else {
+      std::cout << printer_.colors().pass << "All tests passed"
+                << printer_.colors().none << " (" << asserts_.pass
+                << " asserts in " << tests_.pass << " tests)\n";
 
-        if (tests_.skip) {
-          std::cout << tests_.skip << " tests skipped\n";
-        }
-
-        std::cout.flush();
+      if (tests_.skip) {
+        std::cout << tests_.skip << " tests skipped\n";
       }
+
+      std::cout.flush();
     }
   }
 
@@ -1266,7 +1263,7 @@ class runner {
     }
 
     if (not dry_run_) {
-      reporter_.on(events::summary{});
+      report_summary();
     }
 
     if (should_run and fails_) {
@@ -1374,14 +1371,14 @@ class runner {
 
 #if defined(__cpp_exceptions)
     if (not level_) {
-      reporter_.on(events::summary{});
+      report_summary();
     }
     throw fatal_assertion;
 #else
     if (level_) {
       reporter_.on(events::test_end{});
     }
-    reporter_.on(events::summary{});
+    report_summary();
     std::abort();
 #endif
   }
@@ -1399,10 +1396,17 @@ class runner {
     suites_.clear();
 
     if (rc.report_errors) {
-      reporter_.on(events::summary{});
+      report_summary();
     }
 
     return fails_ > 0;
+  }
+
+  auto report_summary() -> void {
+    if (static auto once = true; once) {
+      once = false;
+      reporter_.on(events::summary{});
+    }
   }
 
  protected:
@@ -2287,8 +2291,7 @@ class steps {
               auto i = 0u;
               const auto& ms = utility::match(pattern, _step);
               expr(lexical_cast<TArgs>(ms[i++])...);
-            }
-            (typename type_traits::function_traits<TExpr>::args{});
+            }(typename type_traits::function_traits<TExpr>::args{});
           });
     }
 

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -225,6 +225,24 @@ struct test_sub_sections {
   test_runner& run;
 };
 
+struct test_summary_reporter : ut::reporter<ut::printer> {
+  auto count_summaries(std::size_t& counter) -> void {
+    summary_counter_ = &counter;
+  }
+
+  auto on(ut::events::summary) -> void {
+    if (summary_counter_) {
+      ++*summary_counter_;
+    }
+  }
+
+  std::size_t* summary_counter_{};
+};
+
+struct test_summary_runner : ut::runner<test_summary_reporter> {
+  using runner::reporter_;
+};
+
 namespace ns {
 template <char... Cs>
 constexpr auto operator""_i() -> int {
@@ -715,6 +733,16 @@ int main() {
       test_assert(1 == reporter.tests_.skip);
 
       reporter = printer{};
+    }
+
+    {
+      std::size_t summary_count = 0;
+      {
+        auto run = test_summary_runner{};
+        run.reporter_.count_summaries(summary_count);
+        test_assert(false == run.run({.report_errors = true}));
+      }
+      test_assert(1 == summary_count);
     }
 
     auto& test_cfg = ut::cfg<ut::override>;


### PR DESCRIPTION
Under certain conditions, the reporter's summary handler can be called
by the runner more than once. The default reporter handled such cases
correctly, but the runner can be configured with a user-provided
reporter type that may not align with that assumption. Moving the
responsibility to only call the reporter's summary handler once to the
runner aligns with user expectations and prevents bugs.

Problem:
- The summary handler for `ut::reporter`-like types may be called by `ut::runner` multiple times.

Solution:
- Move the responsibility for checking if the reporter's summary handler has already been called from `ut::reporter` to `ut::runner`.

Issue: #515

Reviewers:
@krzysztof-jusiak
