### PR TITLE
Fix gcc shadow errors.

### DIFF
--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -28,7 +28,7 @@ class private_member_object_value {
   int value;
 
  public:
-  private_member_object_value(int value) : value(value) {}
+  private_member_object_value(int value_) : value(value_) {}
 };
 
 struct public_member_object_value {
@@ -51,7 +51,7 @@ class private_member_object_epsilon {
   int epsilon;
 
  public:
-  private_member_object_epsilon(int epsilon) : epsilon(epsilon) {}
+  private_member_object_epsilon(int epsilon_) : epsilon(epsilon_) {}
 };
 
 struct public_member_object_epsilon {


### PR DESCRIPTION
Problem:
```
/home/runner/work/ut/ut/test/ut/ut.cpp: In constructor ‘test_has_member_object::private_member_object_value::private_member_object_value(int)’:
/home/runner/work/ut/ut/test/ut/ut.cpp:31:42: error: declaration of ‘value’ shadows a member of ‘test_has_member_object::private_member_object_value’ [-Werror=shadow]

/home/runner/work/ut/ut/test/ut/ut.cpp: In constructor ‘test_has_member_object::private_member_object_epsilon::private_member_object_epsilon(int)’:
/home/runner/work/ut/ut/test/ut/ut.cpp:54:46: error: declaration of ‘epsilon’ shadows a member of ‘test_has_member_object::private_member_object_epsilon’ [-Werror=shadow]
```

Solution:
- Rename `value`/`epsilon` to `value_`/`epsilon_`, respectively.

Issue: #

Reviewers:
@krzysztof-jusiak 
