### PR TITLE
Include <source_location> if it is found

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -67,7 +67,7 @@ export import std;
 #include <exception>
 #endif
 
-#if defined(__cpp_lib_source_location)
+#if __has_include(<source_location>)
 #include <source_location>
 #endif
 


### PR DESCRIPTION
Problem:
- Since `__cpp_lib_source_location` is defined in `<source_location>` and `<version>`, it is defined only if  `<source_location>` or `<version>` is included before `<boost/ut.hpp>`.
- If `<source_location>` is included in one test file and not in another test file it triggers a segmentation fault.

Solution:
- Use `#if __has_include(<source_location>)` instead of `#if defined(__cpp_lib_source_location)`.
