### PR TITLE
warning C4702: unreachable code with try catch blocks.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -916,12 +916,12 @@ struct throws_ : op {
       : value_{[&expr] {
           try {
             expr();
+            return false;
           } catch (const TException&) {
             return true;
           } catch (...) {
             return false;
           }
-          return false;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -935,10 +935,10 @@ struct throws_<TExpr, void> : op {
       : value_{[&expr] {
           try {
             expr();
+            return false;
           } catch (...) {
             return true;
           }
-          return false;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
@@ -952,10 +952,10 @@ struct nothrow_ : op {
       : value_{[&expr] {
           try {
             expr();
+            return true;
           } catch (...) {
             return false;
           }
-          return true;
         }()} {}
 
   [[nodiscard]] constexpr operator bool() const { return value_; }


### PR DESCRIPTION
D:\dev\vcpkg\installed\x64-windows\include\boost\ut.hpp(881) : error C2220: the following warning is treated as an error D:\dev\vcpkg\installed\x64-windows\include\boost\ut.hpp(881) : warning C4702: unreachable code D:\dev\vcpkg\installed\x64-windows\include\boost\ut.hpp(881) : warning C4702: unreachable code https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702?view=msvc-170 MSVC treats code after return statements as unreachable. By moving the second return inside the try block then there will no longer be two return statements on catch.

Problem:
- if you warnings and error on warnings on this will trigger an error. MSVC sees code after return statements.

Solution:
- Move the last return statement into the try block.

Issue: #

Reviewers:
@

fixes https://github.com/boost-ext/ut/issues/443
