### PR TITLE
IDE integration: cmd-line & junit-type reporter

### DIFF
--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -11,6 +11,7 @@ function(ut_add_custom_command_or_test)
   include(CMakeParseArguments)
   cmake_parse_arguments("${prefix}" "${noValues}" "${singleValues}" "${multiValues}" ${ARGN})
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
+  target_compile_definitions(${PARSE_TARGET} PRIVATE NOMINMAX)
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
     add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})

--- a/example/cfg/parallel_runner.cpp
+++ b/example/cfg/parallel_runner.cpp
@@ -28,10 +28,10 @@ class parallel_runner : public ut::runner<> {
   [[nodiscard]] auto run() -> bool {
 #if defined(__cpp_lib_parallel_algorithm)
     std::for_each(std::execution::par, std::cbegin(suites_), std::cend(suites_),
-                  [&](const auto& suite) { suite(); });
+                  [&](const auto& suite) { suite.first(); });
 #else
     std::for_each(std::cbegin(suites_), std::cend(suites_),
-                  [&](const auto& suite) { suite(); });
+                  [&](const auto& suite) { suite.first(); });
 #endif
 
     suites_.clear();

--- a/test/ft/test_suite_1.cpp
+++ b/test/ft/test_suite_1.cpp
@@ -7,11 +7,21 @@
 //
 #include "test.hpp"
 
-static test::suite _ = [] {
+static test::suite<"equality tests"> _ = [] {
   using namespace test;
 
+  "printing test"_test = [] {
+    std::cout << "\ntest output to be captured" << std::endl;
+    expect(true);
+  };
+  "empty test"_test = [] { };
+  skip / "skipped test"_test = [] { };
   "equality"_test = [] {
     "should be equal"_test = [] { expect(42_i == 42); };
     "should not be equal"_test = [] { expect(1_i != 2); };
+    "throws"_test = [] {
+      // throw std::runtime_error("throws explicitly");
+    };
+    skip / "skipped nested test"_test = [] { };
   };
 };

--- a/test/ft/test_suite_2.cpp
+++ b/test/ft/test_suite_2.cpp
@@ -7,7 +7,7 @@
 //
 #include "test.hpp"
 
-static test::suite _ = [] {
+static test::suite<"exception tests"> _ = [] {
   using namespace test;
 
   "exceptions/expressions"_test = [] {

--- a/test/ft/test_suite_3.cpp
+++ b/test/ft/test_suite_3.cpp
@@ -7,7 +7,7 @@
 //
 #include "test.hpp"
 
-static test::suite _ = [] {
+static test::suite<"logging suite"> _ = [] {
   using namespace test;
   test::log << "suite:" << int() << double() << '\n';
   expect(type<int> == type<int>);


### PR DESCRIPTION
Hey, this is a follow-up and proof-of-concept for a basic command-line feature as outlined in 
* #550

What has been done:
-
* added Catch 2-style command-line parsing that can be invoked via `boost::ut::detail::cfg::parse(argc, argv);`
   for most compilers/OSes this is done automatically and the definition in `int main(...)` is optional. 
   Windows/MSVC may need to define this explicitly in 'main(..)`. But not a breaking change and fully backward compatible.
* added (legacy-style) junit-type xml reporting
   N.B. to note: the reporter implementation needs/implemented a nested map structure since some of the information/reporting for xml needs to out-of-order w.r.t. the order in which the tests have been executed. This makes it easier w.r.t. having arbitrary post-processed outputs but -- to be evaluated -- impact the performance if there are thousands of tests.
* added an optional 'test_finish' callback for nested test (N.B. 'test_end' was not called for nested tests)
* added compile-time suite naming, e.g.
```cpp
static test::suite<"equality tests"> _ = [] { /* ... */ }
```
* added (optional) `on(events::suite_[begin,end])` callbacks
* added ~60% of functionality outlined in the feature request

What has not been done:
-
* filtering of suites names
* sorting of suites or tests:
   N.B. I have been side-tracked a bit and only realised late that tests can be nested and often -- especially for nested tests -- may depend on external state (<-> lambda captures). This is a bit problematic as this state interfer w.r.t. out-of-order, for example, sorted execution of tests. This could be added but users would need to be aware w.r.t. that using this feature may cause unexpected results depending how they wrote their tests.
* overriding the reporter/printer:
  we need to find the right runtime polymorphisms to switch between various parallel reporter implementation during rutime while keeping the stated constraint in #550:
  > static_polymorphism, variant , either is fine (just not virtual dispatch)
  
  since static_polymorphism doesn't work with runtime arguments this leaves `std::variant` which needs a lot of
wrappers/visitors and would break the 'override cfg' API that many users already use.
N.B. all the changes I introduced should be non-breaking and fully backward compatible. For the time being I wrote (largely a copy of the existing reporter) a junit-capable reporter that collects the required state and results and decides via a run-time parameter whether to export the data to the console/human-readable format or in an xml-junit-like format that IDEs can process. The two reporter implementations are highly redundant/partial-duplicates. Depending on the runtime-capable polymorphism maybe this could be optimised before merging.

### to note/for consideration/open questions:
* most template could be constraint using concepts -> nicer errors in case reporter/printer miss some interfaces
* make some of the required interfaces optional (e.g. via `if constexpr ( requires { ...}) {...})
* lift the 80-column line limit - this makes some of the templates code-structuers hard to read
* use of {fmt} and/or std::format? This would simplify some of the formatting constructs
* there are some type-trait and other template functions that are common and/or solved in C++20 -> switch/replace/reduce?
* Q:  why to reimplement `std::function<...>` and use `void*` store lambdas?
* Q: why use/implement custom filters when there is `std::regex`?  Yes, it may be slow but usually not in the nominal path when all tests are executed and then there is also [ctre](https://github.com/hanickadot/compile-time-regular-expressions). :thinking: 
* there are lot of templating gems. :+1:

Examples:
-
default output `./ft`:
![image](https://user-images.githubusercontent.com/46007894/214404074-2155905f-08ab-4c9f-a757-fd42b4f0ec38.png)
verbose output `./ft --success` or `./ft -s`:
![image](https://user-images.githubusercontent.com/46007894/214404448-a88a9e9e-fff4-4167-b9b9-fa932fa55ea9.png)
junit-style output `./ft --reporter junit` or `./ft -r junit`:
![image](https://user-images.githubusercontent.com/46007894/214404687-47ca8c83-31bc-4866-a4c6-08036a01303e.png)

###And the same with some assertion/exception errors (N.B. modified ft example):
default output `./ft`:
![image](https://user-images.githubusercontent.com/46007894/214405378-b6768e26-4b13-42c6-bbe6-656cc237c024.png)
verbose output `./ft --success` or `./ft -s`:
![image](https://user-images.githubusercontent.com/46007894/214405641-203a0c16-b419-4a2c-8c2c-f9a092c3d1d4.png)
junit-style output `./ft --reporter junit` or `./ft -r junit`:
![image](https://user-images.githubusercontent.com/46007894/214406345-c1303359-4bb4-4068-b9a0-81350914e332.png)

Last but not least:
-
* Thanks for creating UT and making it public. It's really useful for a lot of people and a good lib to show what can be done with C++ and w/o macros! :+1: 
* This PR doesn't claim to be feature complete nor perfect and is meant for review ... am happy to change things as needed.
