### PR TITLE
std::stoll returns long long. It's being assigned to a std::size_t.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -742,13 +742,18 @@ struct cfg {
         // parse size argument
         std::size_t last;
         std::string argument(argv[i]);
-        std::size_t val = std::stoll(argument, &last);
+        long long val = std::stoll(argument, &last);
+        if (val < 0) {
+          std::cerr << "parsed value is negative " << val << std::endl;
+          exit(-1);
+        }
         if (last != argument.length()) {
           std::cerr << "cannot parse option of " << argv[i - 1] << " "
                     << argv[i] << std::endl;
           exit(-1);
         }
-        std::get<std::reference_wrapper<std::size_t>>(var).get() = val;
+        std::get<std::reference_wrapper<std::size_t>>(var).get() =
+          static_cast<std::size_t>(val);
       }
       if (std::holds_alternative<std::reference_wrapper<std::string>>(var)) {
         // parse string argument

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -742,18 +742,13 @@ struct cfg {
         // parse size argument
         std::size_t last;
         std::string argument(argv[i]);
-        long long val = std::stoll(argument, &last);
-        if (val < 0) {
-          std::cerr << "parsed value is negative " << val << std::endl;
-          exit(-1);
-        }
+        std::size_t val = std::stoull(argument, &last);
         if (last != argument.length()) {
           std::cerr << "cannot parse option of " << argv[i - 1] << " "
                     << argv[i] << std::endl;
           exit(-1);
         }
-        std::get<std::reference_wrapper<std::size_t>>(var).get() =
-          static_cast<std::size_t>(val);
+        std::get<std::reference_wrapper<std::size_t>>(var).get() = val;
       }
       if (std::holds_alternative<std::reference_wrapper<std::string>>(var)) {
         // parse string argument


### PR DESCRIPTION
 Added check for negative and cast to std::size_t.

Problem:
- std::stoll returns long long. It's being assigned to a std::size_t.

/mnt/d/dev/OpenVIII_CPP_WIP/cmake-build-debug-wsl-clang15/_deps/ut_fetch-src/include/boost/ut.hpp:745:27: error: implicit conversion changes signedness: 'long long' to 'std::size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
        std::size_t val = std::stoll(argument, &last);
                    ~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

Solution:
- Added check for negative and cast to std::size_t.

Issue: #

Reviewers:
@
