### PR TITLE
Suppress alias when not using CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,10 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 add_library(ut INTERFACE)
+
+if(BOOST_UT_ALLOW_CPM_USE)
 add_library(Boost::ut ALIAS ut)
+endif()
 
 if(NOT DEFINED INCLUDE_INSTALL_DIR)
   set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME}-${PROJECT_VERSION}/include)

--- a/cmake/PackageProject.cmake
+++ b/cmake/PackageProject.cmake
@@ -152,7 +152,7 @@ function(packageProject)
 
   mark_as_advanced("${PROJECT_NAME}_INSTALL_CMAKEDIR")
 
-  configure_file(${PACKAGE_PROJECT_ROOT_PATH}/Config.cmake.in "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" @ONLY)
+  configure_package_config_file(${PACKAGE_PROJECT_ROOT_PATH}/Config.cmake.in "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" INSTALL_DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR}/${PROJECT_NAME}Config.cmake)
 
   install(
     EXPORT ${PROJECT_NAME}Targets


### PR DESCRIPTION
Problem:
When BOOST_UT_ALLOW_CPM_USE is FALSE, both the ut CMakeList and also
packageProject will execute `add_library(Boost::ut ALIAS ut)`. I don't
understand why its not a problem when using CPM's PackageProject, perhaps it
runs in some kind of abstraction that the alias doesn't collide.

Solution:
Don't create the alias ourselves when ALLOW_CPM_USE=FALSE

Issue: #563

Reviewers:
@
