### PR TITLE
Emscripten: add CI and fix/disable unsupported features

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,0 +1,57 @@
+---
+name: Emscripten
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: "**/cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+
+      - name: Install emscripten
+        run: |
+          cd
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          # Download and install the latest SDK tools.
+          ./emsdk install latest
+          # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
+          ./emsdk activate latest
+          # Activate PATH and other environment variables in the current terminal
+          source ./emsdk_env.sh
+
+      - name: configure
+        run: |
+          source ~/emsdk/emsdk_env.sh
+          emcmake cmake -S . -B build -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO
+
+      - name: build
+        run: |
+          source ~/emsdk/emsdk_env.sh
+          cmake --build build -j4
+
+      - name: test
+        run: |
+          source ~/emsdk/emsdk_env.sh
+          cd build
+          ctest --build-config Debug

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -34,9 +34,9 @@ jobs:
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
           # Download and install the latest SDK tools.
-          ./emsdk install latest
+          ./emsdk install releases-03ecb526947f6a3702a0d083083799fe410d3893-64bit
           # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
-          ./emsdk activate latest
+          ./emsdk activate releases-03ecb526947f6a3702a0d083083799fe410d3893-64bit
           # Activate PATH and other environment variables in the current terminal
           source ./emsdk_env.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,11 +102,14 @@ if (EMSCRIPTEN)
   set(CMAKE_EXECUTABLE_SUFFIX ".js")
   target_link_options(ut INTERFACE
           "SHELL:-s ALLOW_MEMORY_GROWTH=1"
-          # "SHELL:-s EXIT_RUNTIME"
+          "SHELL:-s EXIT_RUNTIME=1"
           -fwasm-exceptions
           -g
           )
-
+  target_compile_options(ut INTERFACE
+          -fwasm-exceptions
+          -g
+          )
 endif()
 
 # Note: now we can use the target Boost::ut

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,17 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   )
 endif()
 
+if (EMSCRIPTEN)
+  set(CMAKE_EXECUTABLE_SUFFIX ".js")
+  target_link_options(ut INTERFACE
+          "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+          # "SHELL:-s EXIT_RUNTIME"
+          -fwasm-exceptions
+          -g
+          )
+
+endif()
+
 # Note: now we can use the target Boost::ut
 include(cmake/AddCustomCommandOrTest.cmake)
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -3168,7 +3168,7 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace boost::inline ext::ut::inline v1_1_9
 
-#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
 __attribute__((constructor)) inline void cmd_line_args(int argc,
                                                        const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;

--- a/test/ut/CMakeLists.txt
+++ b/test/ut/CMakeLists.txt
@@ -16,13 +16,14 @@ if(BOOST_UT_ENABLE_MEMCHECK AND BOOST_UT_MEMORYCHECK_COMMAND)
       ${BOOST_UT_MEMORYCHECK_COMMAND}
       --leak-check=full
       --error-exitcode=1
+      ${CMAKE_CROSSCOMPILING_EMULATOR}
       ./${name}_test
     )
   endfunction()
 else()
   function(ut name)
     add_executable(${name}_test ${name}.cpp)
-    ut_add_custom_command_or_test(TARGET ${name}_test COMMAND ${name}_test)
+    ut_add_custom_command_or_test(TARGET ${name}_test COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${name}_test)
   endfunction()
 endif()
 

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1368,7 +1368,7 @@ int main() {
       test_assert(6 == std::size(test_cfg.assertion_calls));
     }
 
-#if __has_include(<unistd.h>) and __has_include(<sys/wait.h>)
+#if __has_include(<unistd.h>) and __has_include(<sys/wait.h>) and not defined(EMSCRIPTEN)
     {
       test_cfg = fake_cfg{};
 


### PR DESCRIPTION
Problem:
I tried using ut in a project which has emscripten as one of it's build targets and hit some issues.

Solution:
Ideally UT would add emscripten as one of it's supported targets with the correct cmake and a CI that ensures that compatibility is not broken over time. 

I realize that asking for supporting a complete new target is a big ask, that's why I start this as a draft PR to:
- show the necessary changes as far as I was able to solve the problems and the remaining problems
- see if others have already experimented in this direction and seek solutions on the outstanding problems
- ask whether the ut maintainers would be interested in adding emscripten and get early feedback

The current state is that the project builds, but the tests do not run through. Things that have been changed:
- [x] added another CI workflow which runs `emcmake`with the latest emscripten release
- [x] removed unsupported commandline parameter parsing based on `__attribute__((constructor))`

The build status can be seen or on the [CI run in my fork](https://github.com/wirew0rm/ut/pull/1) while this action has not been approved) as long as the run is not approved here yet.