### PR TITLE
Add basic CLI implicit argc/argv capturing for MSVC

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -668,8 +668,15 @@ struct cfg {
   static inline reflection::source_location location{};
   static inline bool wip{};
 
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
+    !defined(__EMSCRIPTEN__)
   static inline int largc = 0;
   static inline const char** largv = nullptr;
+#else
+  static inline int largc = __argc;
+  static inline const char** largv = const_cast<const char**>(__argv);
+#endif
+
   static inline std::string executable_name = "unknown executable";
   static inline std::string query_pattern = "";        // <- done
   static inline bool invert_query_pattern = false;     // <- done
@@ -3171,14 +3178,15 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace boost::inline ext::ut::inline v1_1_9
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
+    !defined(__EMSCRIPTEN__)
 __attribute__((constructor)) inline void cmd_line_args(int argc,
                                                        const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;
   ::boost::ut::detail::cfg::largv = argv;
 }
 #else
-// add MSV/windows related code here (optional)
+// For MSVC, largc/largv are initialized with __argc/__argv
 #endif
 
 #endif

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -668,8 +668,7 @@ struct cfg {
   static inline reflection::source_location location{};
   static inline bool wip{};
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
-    !defined(__EMSCRIPTEN__)
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
   static inline int largc = 0;
   static inline const char** largv = nullptr;
 #else
@@ -3178,8 +3177,7 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace boost::inline ext::ut::inline v1_1_9
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
-    !defined(__EMSCRIPTEN__)
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
 __attribute__((constructor)) inline void cmd_line_args(int argc,
                                                        const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -668,12 +668,12 @@ struct cfg {
   static inline reflection::source_location location{};
   static inline bool wip{};
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
-  static inline int largc = 0;
-  static inline const char** largv = nullptr;
-#else
+#if defined(_MSC_VER)
   static inline int largc = __argc;
   static inline const char** largv = const_cast<const char**>(__argv);
+#else
+  static inline int largc = 0;
+  static inline const char** largv = nullptr;
 #endif
 
   static inline std::string executable_name = "unknown executable";
@@ -3177,7 +3177,8 @@ using operators::operator/;
 using operators::operator>>;
 }  // namespace boost::inline ext::ut::inline v1_1_9
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && !defined(__EMSCRIPTEN__)
+#if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
+    !defined(__EMSCRIPTEN__)
 __attribute__((constructor)) inline void cmd_line_args(int argc,
                                                        const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;


### PR DESCRIPTION
This simply adds same basic args injection for Windows system.

Problem:
- CLI introduced in #553 did not support MSVC

Solution:

There is no `__attribute__((constructor))` equivalent for MSVC and the closest mechanism I have found ([init_seg](https://learn.microsoft.com/en-us/cpp/preprocessor/init-seg)) did not help. Global/static variables initialization order seems to be not so obvious problem.

For now, `__argc`/`__argv` are simply used to initialize global `cfg::largc`/`cfg::largv`.

Follow up for issue #550

---

PS. I am about to open PR with proposal for explicit `argc`/`argv` passing through manual `ut::cfg<>.run` call.
