### PR TITLE
Implements streaming for invocable types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,28 @@ tests:   0 | 2 failed
 asserts: 0 | 0 passed | 2 failed
 ```
 
+> I use `std::expected`, can I stream its `error()` upon failure?
+> Yes, since `std::expected`'s `error()` can only be called when there is no
+> value it requires lazy evaluation.
+
+```cpp
+lazy log"_test = [] {
+  std::expected<bool, std::string> e = std::unexpected("lazy evaluated");
+  expect(e.has_value()) << [&] { return e.error(); } << fatal;
+  expect(e.value() == true);
+};
+
+```
+
+```
+Running test "lazy log"... FAILED
+in: main.cpp:12 - test condition:  [false]
+
+ lazy evaluated
+===============================================================================
+tests:   1 | 2 failed
+asserts: 0 | 0 passed | 2 failed
+
 > https://godbolt.org/z/v2PDuU
 
 </p>

--- a/example/log.cpp
+++ b/example/log.cpp
@@ -7,6 +7,11 @@
 //
 #include <boost/ut.hpp>
 
+#if __has_include(<expected>)
+#include <expected>
+#include <string>
+#endif
+
 int main() {
   using namespace boost::ut;
 
@@ -15,4 +20,16 @@ int main() {
     expect(42_i == 42) << "message on failure";
     boost::ut::log << "post";
   };
+
+#if defined(__cpp_lib_expected)
+  "lazy log"_test = [] {
+    // It's not possible to write a test like:
+    //   expect(e.has_value()) << e.error() << fatal;
+    // This would evaluate e.error() when there is no error, instead lazy
+    // evaluation is needed.
+    std::expected<bool, std::string> e = true;
+    expect(e.has_value()) << [&] { return e.error(); } << fatal;
+    expect(e.value() == true);
+  };
+#endif
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -57,6 +57,7 @@ export import std;
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -66,6 +67,7 @@ export import std;
 #include <sstream>
 #include <stack>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -2353,7 +2355,15 @@ struct expect_ {
   auto& operator<<(const TMsg& msg) {
     if (not value_) {
       on<T>(events::log{' '});
-      on<T>(events::log{msg});
+      if constexpr (requires {
+                      requires std::invocable<TMsg> and
+                                   not std::is_void_v<
+                                       std::invoke_result_t<TMsg>>;
+                    }) {
+        on<T>(events::log{std::invoke(msg)});
+      } else {
+        on<T>(events::log{msg});
+      }
     }
     return *this;
   }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -916,6 +916,20 @@ int main() {
     }
 
     {
+      test_cfg = fake_cfg{};
+      auto f = [] { return "msg"; };
+      expect(false) << f;
+
+      test_assert(1 == std::size(test_cfg.assertion_calls));
+
+      test_assert("false" == test_cfg.assertion_calls[0].expr);
+      test_assert(not test_cfg.assertion_calls[0].result);
+      test_assert(2 == std::size(test_cfg.log_calls));
+      test_assert(' ' == std::any_cast<char>(test_cfg.log_calls[0]));
+      test_assert("msg"sv == std::any_cast<const char*>(test_cfg.log_calls[1]));
+    }
+
+    {
       struct convertible_to_bool {
         constexpr operator bool() const { return false; }
       };


### PR DESCRIPTION
Sometimes it's needed to write a custom message that can only be written when the test fails. It's not possible to directly steam these messages, instead lazy evaluation is needed. A typical example is to stream a std::expected's error when it has no value. This is implemented by using a callable that is only called when ut's expect fails.