### PR TITLE
Adds format support for logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ All tests passed (2 asserts in 2 tests)
 <details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;Misc</summary>
 <p>
 
-<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Logging</summary>
+<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Logging using streams</summary>
 <p>
 
 ```cpp
@@ -1040,6 +1040,36 @@ Running "logging"...
 pre
   logging.cpp:8:FAILED [42 == 43] message on failure
 post
+FAILED
+
+===============================================================================
+
+tests:   1 | 1 failed
+asserts: 1 | 0 passed | 1 failed
+```
+
+> https://godbolt.org/z/26fPSY
+
+</p>
+</details>
+
+<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Logging using formatting</summary>
+<p>
+This requires using C++20 with a standard library with std::format support.
+
+```cpp
+"logging"_test = [] {
+  log("\npre  {} == {}\n", 42, 43);
+  expect(42_i == 43) << "message on failure";
+  log("\npost {} == {} -> {}\n", 42, 43, 42 == 43);
+};
+```
+
+```
+Running "logging"...
+pre  42 == 43
+  logging.cpp:8:FAILED [42 == 43] message on failure
+post 42 == 43 -> false
 FAILED
 
 ===============================================================================

--- a/example/log.cpp
+++ b/example/log.cpp
@@ -32,4 +32,12 @@ int main() {
     expect(e.value() == true);
   };
 #endif
+
+#if defined(BOOST_UT_HAS_FORMAT)
+  "log format"_test = [] {
+    boost::ut::log("\npre: {}\n", 42);
+    expect(42_i == 42) << "message on failure";
+    boost::ut::log("\npost\n");
+  };
+#endif
 }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -18,6 +18,10 @@
 #include <string_view>
 #include <vector>
 
+#if __has_include(<format>)
+#include <format>
+#endif
+
 namespace ut = boost::ut;
 
 namespace test_has_member_object {
@@ -895,7 +899,22 @@ int main() {
       test_assert(' ' == std::any_cast<char>(test_cfg.log_calls[6]));
       test_assert(42 == std::any_cast<int>(test_cfg.log_calls[7]));
     }
+#if defined(BOOST_UT_HAS_FORMAT)
+    {
+      test_cfg = fake_cfg{};
 
+      "logging with format"_test = [] {
+        boost::ut::log("{:<10} {:#x}\n{:<10} {}\n", "expected:", 42,
+                       std::string("actual:"), 99);
+      };
+
+      test_assert(1 == std::size(test_cfg.run_calls));
+      test_assert("logging with format"sv == test_cfg.run_calls[0].name);
+      test_assert(1 == std::size(test_cfg.log_calls));
+      test_assert("expected:  0x2a\nactual:    99\n"sv ==
+                  std::any_cast<std::string>(test_cfg.log_calls[0]));
+    }
+#endif
     {
       test_cfg = fake_cfg{};
       expect(true) << "true msg" << true;


### PR DESCRIPTION
This makes it possible to use the C++20 formatting library next to the existing stream operator when creating log messages. This feature is only available when the standard library used has format support.