### PR TITLE
Fix compilation if std::format_string is not known

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2265,11 +2265,19 @@ struct log {
   }
 
 #if defined(BOOST_UT_HAS_FORMAT)
+#if __cpp_lib_format >= 202207L
   template <class... Args>
   void operator()(std::format_string<Args...> fmt, Args&&... args) {
     on<std::string>(
         events::log{std::vformat(fmt.get(), std::make_format_args(args...))});
   }
+#else
+  template <class... Args>
+  void operator()(std::string_view fmt, Args&&... args) {
+    on<std::string>(
+        events::log{std::vformat(fmt, std::make_format_args(args...))});
+  }
+#endif
 #endif
 };
 


### PR DESCRIPTION
Problem:
- `std::format_string` was retroactively exposed in C++20 by [P2508R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2508r1.html)

Some STL implementations may not have it implemented (e.g. one shipped with MSVC cl.exe 19.34.31935).

Solution:
- Check feature test flag `__cpp_lib_format >= 202207L`, use `std::string_view` when too old.
- Alternatively, we could require `__cpp_lib_format >= 202207L` to enable `BOOST_UT_HAS_FORMAT`
