### PR TITLE
allow use of ranges with parameterized tests

### DIFF
--- a/example/parameterized.cpp
+++ b/example/parameterized.cpp
@@ -6,6 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/ut.hpp>
+#include <ranges>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -25,6 +26,11 @@ int main() {
   "args"_test = [](auto arg) {
     expect(arg > 0_i) << "all values greater than 0";
   } | std::vector{1, 2, 3};
+
+  /// Alternative syntax
+  "views"_test = [](auto arg) {
+    expect(arg > 0_i) << "all values greater than 0";
+  } | std::views::iota(1, 4);
 
   /// Alternative syntax
   "types"_test = []<class T>() {

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -414,14 +414,14 @@ int main() {
 
     {
       struct foo {};
-      static_assert(type_traits::is_container_v<std::vector<int>>);
-      static_assert(type_traits::is_container_v<std::array<bool, 0>>);
-      static_assert(type_traits::is_container_v<std::string>);
-      static_assert(type_traits::is_container_v<std::string_view>);
-      static_assert(type_traits::is_container_v<std::map<int, int>>);
-      static_assert(not type_traits::is_container_v<int>);
-      static_assert(not type_traits::is_container_v<foo>);
-      static_assert(not type_traits::is_container_v<void>);
+      static_assert(type_traits::is_range_v<std::vector<int>>);
+      static_assert(type_traits::is_range_v<std::array<bool, 0>>);
+      static_assert(type_traits::is_range_v<std::string>);
+      static_assert(type_traits::is_range_v<std::string_view>);
+      static_assert(type_traits::is_range_v<std::map<int, int>>);
+      static_assert(not type_traits::is_range_v<int>);
+      static_assert(not type_traits::is_range_v<foo>);
+      static_assert(not type_traits::is_range_v<void>);
     }
 
     {


### PR DESCRIPTION
Problem:
- can't use `std::ranges::iota_view` or other views.

Solution:
- don't require the `value_type` static member typedef

Issue: #

Reviewers:
@
