### PR TITLE
Workaround for segfault on Clang 17 and possibly others.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -797,7 +797,7 @@ struct cfg {
   }
 
   static inline void parse(int argc, const char* argv[]) {
-    const std::size_t n_args = static_cast<std::size_t>(argc);
+    const std::size_t n_args = 0; // static_cast<std::size_t>(argc);
     if (n_args > 0 && argv != nullptr) {
       cfg::largc = argc;
       cfg::largv = argv;


### PR DESCRIPTION
Problem:
- #566: Segfault on Clang (I believe I saw the same on MSVC 2022)

Solution:
- This is not a solution but just a quick'n'dirty fix. Only made this to clarify what the problem is related to, and as a stopgap for those who need a solution right away.

Issue: #566 

Reviewers:
@
