### PR TITLE
Fix MSVC warnings and compile errors

### DIFF
--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -11,7 +11,6 @@ function(ut_add_custom_command_or_test)
   include(CMakeParseArguments)
   cmake_parse_arguments("${prefix}" "${noValues}" "${singleValues}" "${multiValues}" ${ARGN})
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
-  target_compile_definitions(${PARSE_TARGET} PRIVATE NOMINMAX)
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
     add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})

--- a/example/log.cpp
+++ b/example/log.cpp
@@ -7,7 +7,7 @@
 //
 #include <boost/ut.hpp>
 
-#if __has_include(<expected>)
+#ifdef __cpp_lib_expected
 #include <expected>
 #include <string>
 #endif

--- a/example/sl.cpp
+++ b/example/sl.cpp
@@ -10,11 +10,24 @@
 int main() {
   using namespace boost::ut;
 
+#if defined(_MSC_VER) and not defined(__clang__)
+  // MSVC fails if the `""_i` literal operator is used inside the 'verify' lambda:
+  // "sl.cpp(16,37): error C3688: invalid literal suffix '_i'; literal operator or literal operator template 'operator ""_i' not found"
   "sl"_test = [] {
-    constexpr auto verify = [](auto sl, auto i) {
+    static constexpr auto _42_i = 42_i;
+    auto verify = [](auto sl, auto i) {
+      expect(i == _42_i, sl) << "error with given source location";
+    };
+
+    verify(boost::ut::reflection::source_location::current(), 42_i);
+  };
+#else
+  "sl"_test = [] {
+    auto verify = [](auto sl, auto i) {
       expect(i == 42_i, sl) << "error with given source location";
     };
 
     verify(boost::ut::reflection::source_location::current(), 42_i);
   };
+#endif
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -19,6 +19,12 @@ export import std;
 #endif
 
 #include <version>
+#if defined(_MSC_VER)
+  #pragma push_macro("min")
+  #pragma push_macro("max")
+  #undef min
+  #undef max
+#endif
 // Before libc++ 17 had experimental support for format and it required a
 // special build flag. Currently libc++ has not implemented all C++20 chrono
 // improvements. Therefore doesn't define __cpp_lib_format, instead query the
@@ -3281,6 +3287,11 @@ __attribute__((constructor)) inline void cmd_line_args(int argc,
 }
 #else
 // For MSVC, largc/largv are initialized with __argc/__argv
+#endif
+
+#if defined(_MSC_VER)
+  #pragma pop_macro("min")
+  #pragma pop_macro("max")
 #endif
 
 #endif

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -11,6 +11,7 @@
 #include <any>
 #include <array>
 #include <cstdlib>
+#include <iostream>
 #include <map>
 #include <numeric>
 #include <sstream>
@@ -82,7 +83,7 @@ constexpr auto to_string = [](const auto expr) {
   return printer.str();
 };
 
-constexpr auto test_assert =
+auto test_assert =
     [](const bool result, const ut::reflection::source_location& sl =
                               ut::reflection::source_location::current()) {
       if (not result) {

--- a/test/ut/win_compat_test.cpp
+++ b/test/ut/win_compat_test.cpp
@@ -7,6 +7,8 @@
 //
 
 // ensure no conflict between `Windows.h` and `ut.hpp`
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
 
 #include "boost/ut.hpp"

--- a/test/ut/win_compat_test.cpp
+++ b/test/ut/win_compat_test.cpp
@@ -7,11 +7,17 @@
 //
 
 // ensure no conflict between `Windows.h` and `ut.hpp`
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <Windows.h>
 
+#if not defined(min) || not defined(max)
+#error 'min' and 'max' should be defined
+#endif
+
 #include "boost/ut.hpp"
+
+#if not defined(min) || not defined(max)
+#error 'min' and 'max' should still be defined
+#endif
 
 namespace ut = boost::ut;
 


### PR DESCRIPTION
Problem:
- `warning STL4038: The contents of <expected> are available only with C++23 or later.`
- `sl.cpp(15,19): error C3688: invalid literal suffix '_i'; literal operator or literal operator template 'operator ""_i' not found`
- `ut.cpp(93,5): error C7595: 'std::source_location::current': call to immediate function is not a constant expression`
  - See reported bug [here](https://developercommunity.visualstudio.com/t/Error-calling-consteval-function-from-an/1669482).
- `std::max` clashes with `Windows.h` `max()` macro.

Solution:
- Use `#ifdef __cpp_lib_expected` instead of `__has_include(<expected>)`, the latter isn't reliable.
- Make sure `ut.hpp` is compatible with `Windows.h` (push & pop `min` & `max`).
- Work around bugs in MSVC.

**Note** that we also need #592 for the build to pass (after the rename from `is_container_v` to `is_range_v`).
**Also** there are still 7 of the unit tests (`ut.cpp`) that fails (#600) which is the case for MSVC as well.

Issue: #579

Reviewers:
@kris-jusiak 
