### PR TITLE
Fix `win_compat_test.cpp` when building with mingw

### DIFF
--- a/test/ut/win_compat_test.cpp
+++ b/test/ut/win_compat_test.cpp
@@ -9,14 +9,18 @@
 // ensure no conflict between `Windows.h` and `ut.hpp`
 #include <Windows.h>
 
-#if not defined(min) || not defined(max)
-#error 'min' and 'max' should be defined
+#ifndef __MINGW32__
+  #if not defined(min) || not defined(max)
+    #error 'min' and 'max' should be defined
+  #endif
 #endif
 
 #include "boost/ut.hpp"
 
-#if not defined(min) || not defined(max)
-#error 'min' and 'max' should still be defined
+#ifndef __MINGW32__
+  #if not defined(min) || not defined(max)
+    #error 'min' and 'max' should still be defined
+  #endif
 #endif
 
 namespace ut = boost::ut;


### PR DESCRIPTION
Problem:
- Preprocessor error out since `mingw-gcc` doesn't define `min` or `max` in its `Windows.h` header.

Solution:
- Don't check for `min` or `max` defines when building with mingw.

Reviewers:
@kris-jusiak 
