### PR TITLE
MSVC named module enablement

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -6,6 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
+#define BOOST_UT_MODULE_MODE
 export module boost.ut;
 export import std;
 #define BOOST_UT_EXPORT export
@@ -14,6 +15,7 @@ export import std;
 #define BOOST_UT_EXPORT
 #endif
 
+#if !defined(BOOST_UT_MODULE_MODE) && !defined(_MSC_VER)
 #if __has_include(<iso646.h>)
 #include <iso646.h>  // and, or, not, ...
 #endif
@@ -24,6 +26,7 @@ export import std;
   #pragma push_macro("max")
   #undef min
   #undef max
+#endif
 #endif
 // Before libc++ 17 had experimental support for format and it required a
 // special build flag. Currently libc++ has not implemented all C++20 chrono
@@ -72,6 +75,7 @@ export import std;
 #define __has_builtin(...) __has_##__VA_ARGS__
 #endif
 
+#if !defined(BOOST_UT_MODULE_MODE) && !defined(_MSC_VER)
 #include <algorithm>
 #include <array>
 #include <chrono>
@@ -97,12 +101,19 @@ export import std;
 #if defined(__cpp_exceptions)
 #include <exception>
 #endif
-
 #if __has_include(<format>)
 #include <format>
 #endif
 #if __has_include(<source_location>)
 #include <source_location>
+#endif
+#endif
+
+#if defined(BOOST_UT_MODULE_MODE) && defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 5244) // '#include <stdlib.h>' in the purview of module 'boost.ut' appears erroneous.
+#include <stdlib.h>
+#pragma warning(pop)
 #endif
 
 struct _unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct {
@@ -2749,6 +2760,9 @@ namespace terse {
 #pragma clang diagnostic ignored "-Wunused-comparison"
 #endif
 
+// error C2294: cannot export symbol 'boost::ext::ut::vx_y_z::operators::terse::_t' because it has internal linkage
+// error C2294: cannot export symbol 'boost::ext::ut::vx_y_z::operators::terse::operator %' because it has internal linkage
+#if !(defined(BOOST_UT_MODULE_MODE) && defined(_MSC_VER))
 [[maybe_unused]] constexpr struct {
 } _t;
 
@@ -2756,6 +2770,7 @@ template <class T>
 constexpr auto operator%(const T& t, const decltype(_t)&) {
   return detail::value<T>{t};
 }
+#endif
 
 template <class T>
 inline auto operator>>(const T& t,
@@ -3289,7 +3304,7 @@ __attribute__((constructor)) inline void cmd_line_args(int argc,
 // For MSVC, largc/largv are initialized with __argc/__argv
 #endif
 
-#if defined(_MSC_VER)
+#if !defined(BOOST_UT_MODULE_MODE) && defined(_MSC_VER)
   #pragma pop_macro("min")
   #pragma pop_macro("max")
 #endif


### PR DESCRIPTION
Problem:
Consuming ut as a named module using MSVC has compiler errors.

Solution:
- Don't include STL headers. (It results in ODR violation when consuming `std` as module.)
  - MS-STL is the only implementation to date with proper `import std` capable export definitions implemented as a named module and not as a header unit.
- Skip the definition of a symbol with internal linkage.

The proposed changes work with a downstream project that builds both the standard binary interface module (from `std.ixx`) and ut (by renaming `ut.hpp` to `ut.ixx`).

```c++
import boost.ut;

int main()
{
	using namespace boost::ut;
	"test-basic"_test = [] {
		int i = 42;
		expect(42_i == i);
	};

	return 0;
}
```

Builds as:

```
C:\Kellekek\Kitware\CMake\3.28.0\bin\cmake.exe --build C:/Users/mate/Source/Repos/OpenCL-Module/.vscode/build/msbuild-msvc-v143 --config Debug --target test-basic -- /nologo /verbosity:minimal

   1>Checking Build System
   Building Custom Rule C:/Users/mate/Source/Repos/OpenCL-Module/CMakeLists.txt
   Scanning sources for module dependencies...
   std.ixx
   Compiling...
   std.ixx
   StandardLibraryModule.vcxproj -> C:\Users\mate\Source\Repos\OpenCL-Module\.vscode\build\msbuild-msvc-v143\StandardLibraryModule.dir\Debug\StandardLibraryModule.lib
   1>Copying ut.hpp as ut.ixx
   Building Custom Rule C:/Users/mate/Source/Repos/OpenCL-Module/tests/CMakeLists.txt
   Scanning sources for module dependencies...
   ut.ixx
   Compiling...
   ut.ixx
   BoostUtModule.vcxproj -> C:\Users\mate\Source\Repos\OpenCL-Module\.vscode\build\msbuild-msvc-v143\tests\BoostUtModule.dir\Debug\BoostUtModule.lib
   Building Custom Rule C:/Users/mate/Source/Repos/OpenCL-Module/tests/CMakeLists.txt
   test-basic.cpp
   test-basic.vcxproj -> C:\Users\mate\Source\Repos\OpenCL-Module\.vscode\build\msbuild-msvc-v143\tests\Debug\test-basic.exe
```

The proposed changes don't build ut's own test infra, because none of the tests support `import std`. How should I go about adding support for that?

Issue: #558

Reviewers:
@kris-jusiak
