### PR TITLE
ut.hpp: Corrected XML formatting issue in print_junit_summary

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1975,7 +1975,7 @@ class reporter_junit {
       if (result.report_string.empty() && result.nested_tests->empty()) {
         stream << " />\n";
       } else if (!result.nested_tests->empty()) {
-        stream << " />\n";
+        stream << " >\n";
         print_result(stream, suite_name, indent + "  ", result);
         stream << indent << "</testcase>\n";
       } else if (!result.report_string.empty()) {


### PR DESCRIPTION
Previously, an empty element tag was erroneously used in place of an opening XML tag within the print_junit_summary function. This resulted in the generation of invalid XML output. The issue has been resolved by replacing the empty element tag with the appropriate opening XML tag, ensuring the XML output adheres to the expected format.

Problem:
Invalid XML generation

Solution:
Use opening XML tag in place of an empty element tag
