### PR TITLE
Fix: Ensure Command Line Arguments Are Respected in Clang Compilation

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -3312,7 +3312,7 @@ using operators::operator>>;
 
 #if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
     !defined(__EMSCRIPTEN__)
-__attribute__((constructor)) inline void cmd_line_args(int argc,
+__attribute__((constructor(101))) inline void cmd_line_args(int argc,
                                                        const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;
   ::boost::ut::detail::cfg::largv = argv;


### PR DESCRIPTION
Resolved an issue where command line arguments were ignored, specifically when the program was compiled with Clang. The problem was addressed by correctly assigning the priority in __attribute__((constructor(101))), ensuring proper initialization and consistent behavior across compilation environments."

Problem:
Command line arguments were ignored, specifically when the program was compiled with Clang.

Solution:
Assigning the priority in `__attribute__((constructor(101))) inline void cmd_line_args(int argc, const char* argv[])`

Issue: #590

Reviewers:
@krzysztof-jusiak
