### PR TITLE
Fix a segmentation fault caused by a negative argc

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -803,7 +803,7 @@ struct cfg {
   }
 
   static inline void parse(int argc, const char* argv[]) {
-    const std::size_t n_args = static_cast<std::size_t>(argc);
+    const std::size_t n_args = argc > 0 ? static_cast<std::size_t>(argc) : 0U;
     if (n_args > 0 && argv != nullptr) {
       cfg::largc = argc;
       cfg::largv = argv;


### PR DESCRIPTION

Problem:
- With MinGW on windows and maybe on other platforms the cmd_line_args function sets cfg::largc to -1 and trigger a segmentation fault in parse.

Solution:
- if `argc < 0` then use 0 instead in parse.

Issue: #

Reviewers:
@
