### PR TITLE
Add missing newline to print_console_summary

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1890,7 +1890,7 @@ class reporter_junit {
         err_stream
             << "\n========================================================"
                "=======================\n"
-            << "Suite " << suite_name  //
+            << "Suite " << suite_name << '\n' //
             << "tests:   " << (suite_result.n_tests) << " | " << color_.fail
             << suite_result.fails << " failed" << color_.none << '\n'
             << "asserts: " << (suite_result.assertions) << " | "


### PR DESCRIPTION
Problem:
Without a newline, the suit name and "tests" label are not separated.

    ===============================================================================
    Suite globaltests:   0 | 1 failed
    asserts: 0 | 0 passed | 1 failed

Solution:
Add newline

    ===============================================================================
    Suite global
    tests:   0 | 1 failed
    asserts: 0 | 0 passed | 1 failed

Issue: #

Reviewers:
@
