### PR TITLE
Add Option for Enabling Install Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,12 @@ option(BOOST_UT_ENABLE_SANITIZERS "Run static analysis" OFF)
 option(BOOST_UT_BUILD_BENCHMARKS "Build the benchmarks" OFF)
 option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_BUILD_TESTS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
+option(BOOST_UT_ENABLE_INSTALL "Enable install targets" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_USE_WARNINGS_AS_ERORS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
 option(BOOST_UT_ALLOW_CPM_USE "Do not reach out across network for CPM" ON)
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
+if(BOOST_UT_ENABLE_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
   if(BOOST_UT_ALLOW_CPM_USE)
     # ---- Add dependencies via CPM ----
     # see https://github.com/cpm-cmake/CPM.cmake for more info
@@ -83,7 +84,7 @@ if(BOOST_UT_DISABLE_MODULE)
   target_compile_definitions(ut INTERFACE BOOST_UT_DISABLE_MODULE)
 endif()
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
+if(BOOST_UT_ENABLE_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
   # Create target Boost::ut and install target
   packageProject(
     NAME ${PROJECT_NAME}


### PR DESCRIPTION
Problem:
- Cannot disable UT install targets when UT is included as a subproject.

Solution:
- Add a `BOOST_UT_ENABLE_INSTALL` option for enabling installation targets. By default, this variable is enabled if the project is a top-level project (not a subproject).

Issue: #633

Reviewers:
@
