### PR TITLE
little fix cmake + little fix github pipelines

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -43,7 +43,7 @@ jobs:
       - name: configure
         run: |
           source ~/emsdk/emsdk_env.sh
-          emcmake cmake -S . -B build -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO
+          emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO
 
       - name: build
         run: |

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -43,15 +43,16 @@ jobs:
       - name: configure
         run: |
           source ~/emsdk/emsdk_env.sh
-          emcmake cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO
+          emcmake cmake -S . -B build -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF
+
 
       - name: build
         run: |
           source ~/emsdk/emsdk_env.sh
-          cmake --build build -j4
+          cmake --build build -j4 --verbose
 
       - name: test
         run: |
           source ~/emsdk/emsdk_env.sh
           cd build
-          ctest --build-config Debug
+          ctest --build-config Debug -j4 --verbose

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        with:
-          path: "**/cpm_modules"
-          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: "**/cpm_modules"
+      #     key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: Install emscripten
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -46,4 +46,4 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --build-config Debug -j4
+          ctest --build-config Debug -j4 --verbose

--- a/.github/workflows/install_download_all.yml
+++ b/.github/workflows/install_download_all.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: build and install library
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -DBOOST_UT_ENABLE_INSTALL=ON --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCPM_DOWNLOAD_ALL=1 -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -DBOOST_UT_ENABLE_INSTALL=ON --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF
           cmake --build build --target all -j4 --verbose
           cmake --install build --prefix ./install_dir
           rm -rf build

--- a/.github/workflows/install_download_all.yml
+++ b/.github/workflows/install_download_all.yml
@@ -46,4 +46,4 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --build-config Debug -j4
+          ctest --build-config Debug -j4 --verbose

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,12 +29,12 @@ jobs:
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: configure
-        run: cmake -S . -B build -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF
 
       - name: build
-        run: cmake --build build -j4
+        run: cmake --build build -j4 --verbose
 
       - name: test
         run: |
           cd build
-          ctest --build-config Debug
+          ctest --build-config Debug -j4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,4 +37,4 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --build-config Debug -j4
+          ctest --build-config Debug -j4 --verbose

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run:
           brew install pipx
-          pip3 install builddriver cmake_format==0.6.11 pyyaml
+          pipx install builddriver cmake_format==0.6.11 pyyaml
 
       - name: configure
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install builddriver
         shell: bash
         run:
-          pipx install builddriver cmake_format==0.6.11 PyYAML
+          pipx install builddriver cmake_format==0.6.11 pyaml
 
       - name: configure
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,16 +39,16 @@ jobs:
         shell: bash
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF
 
       - name: build
-        run: cmake --build build -j4
+        run: cmake --build build -j4 --verbose
 
       - name: test
         shell: bash
         run: |
           cd build
-          ctest --build-config Debug
+          ctest --build-config Debug -j4 
 
       - name: Run clang-tidy
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,9 @@ jobs:
 
       - name: Install builddriver
         shell: bash
-        run: pip3 install builddriver cmake_format==0.6.11 pyyaml
+        run:
+          brew install pipx
+          pip3 install builddriver cmake_format==0.6.11 pyyaml
 
       - name: configure
         shell: bash
@@ -48,7 +50,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          ctest --build-config Debug -j4 
+          ctest --build-config Debug -j4 --verbose
 
       - name: Run clang-tidy
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install builddriver
         shell: bash
         run:
-          pipx install builddriver cmake_format==0.6.11 pyyaml
+          pipx install builddriver cmake_format==0.6.11 PyYAML
 
       - name: configure
         shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,12 +29,11 @@ jobs:
 
       - name: Install ninja and python
         shell: bash
-        run: brew install llvm clang-format ninja python
+        run: brew install llvm clang-format ninja python pipx
 
       - name: Install builddriver
         shell: bash
         run:
-          brew install pipx
           pipx install builddriver cmake_format==0.6.11 pyyaml
 
       - name: configure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,4 +44,4 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --build-config Debug -j4
+          ctest --build-config Debug -j4 --verbose

--- a/.github/workflows/windows_shared.yml
+++ b/.github/workflows/windows_shared.yml
@@ -1,5 +1,5 @@
 ---
-name: Windows
+name: Windows_shared
 
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
 
       - name: configure
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -DBOOST_UT_DISABLE_MODULE=ON --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF -G "Visual Studio 17 2022" -T ${{matrix.toolset}} -DCMAKE_CXX_STANDARD:STRING=${{matrix.std}}
+          cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DBOOST_UT_ENABLE_RUN_AFTER_BUILD=NO -DBOOST_UT_DISABLE_MODULE=ON --log-level=DEBUG -DFETCHCONTENT_QUIET=OFF -G "Visual Studio 17 2022" -T ${{matrix.toolset}} -DCMAKE_CXX_STANDARD:STRING=${{matrix.std}}
 
       - name: build
         run: cmake --build build --config Debug -j4 --verbose

--- a/.github/workflows/windows_shared.yml
+++ b/.github/workflows/windows_shared.yml
@@ -44,4 +44,4 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --build-config Debug -j4
+          ctest --build-config Debug -j4 --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build*
 /.vs
 /checks.json
 /.vscode
+install_dir/
+cmake_build*/
+compile_commands.json
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 option(BOOST_UT_ENABLE_MEMCHECK "Run the unit tests and examples under valgrind if it is found" OFF)
 option(BOOST_UT_ENABLE_COVERAGE "Run coverage" OFF)
-option(BOOST_UT_ENABLE_SANITIZERS "Run static analysis" OFF)
+option(BOOST_UT_ENABLE_SANITIZERS "Build with sanitizers" OFF)
 option(BOOST_UT_BUILD_BENCHMARKS "Build the benchmarks" OFF)
 option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_BUILD_TESTS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
@@ -50,11 +50,12 @@ add_custom_command(
 
 if(BOOST_UT_ENABLE_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb3 -O0")
 endif()
 
 if(BOOST_UT_ENABLE_SANITIZERS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak -fsanitize=undefined")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer
+  -fsanitize=address,leak,undefined")
 endif()
 
 if(BOOST_UT_DISABLE_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ endif()
 
 if(BOOST_UT_ENABLE_SANITIZERS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer
-  -fsanitize=address,leak,undefined")
+  -fsanitize=address,leak,undefined"
+  )
 endif()
 
 if(BOOST_UT_DISABLE_MODULE)
@@ -82,18 +83,10 @@ if(NOT TARGET Boost::ut)
   add_library(Boost::ut ALIAS ut)
 endif()
 
-if (EMSCRIPTEN)
+if(EMSCRIPTEN)
   set(CMAKE_EXECUTABLE_SUFFIX ".js")
-  target_link_options(ut INTERFACE
-          "SHELL:-s ALLOW_MEMORY_GROWTH=1"
-          "SHELL:-s EXIT_RUNTIME=1"
-          -fwasm-exceptions
-          -g
-          )
-  target_compile_options(ut INTERFACE
-          -fwasm-exceptions
-          -g
-          )
+  target_link_options(ut INTERFACE "SHELL:-s ALLOW_MEMORY_GROWTH=1" "SHELL:-s EXIT_RUNTIME=1" -fwasm-exceptions -g)
+  target_compile_options(ut INTERFACE -fwasm-exceptions -g)
 endif()
 
 # Note: now we can use the target Boost::ut

--- a/example/parameterized.cpp
+++ b/example/parameterized.cpp
@@ -28,9 +28,11 @@ int main() {
   } | std::vector{1, 2, 3};
 
   /// Alternative syntax
+#ifndef __EMSCRIPTEN__
   "views"_test = [](auto arg) {
     expect(arg > 0_i) << "all values greater than 0";
   } | std::views::iota(1, 4);
+#endif
 
   /// Alternative syntax
   "types"_test = []<class T>() {

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -20,10 +20,10 @@ export import std;
 
 #include <version>
 #if defined(_MSC_VER)
-  #pragma push_macro("min")
-  #pragma push_macro("max")
-  #undef min
-  #undef max
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
 #endif
 // Before libc++ 17 had experimental support for format and it required a
 // special build flag. Currently libc++ has not implemented all C++20 chrono
@@ -77,6 +77,7 @@ export import std;
 #include <chrono>
 #include <concepts>
 #include <cstdint>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -89,7 +90,6 @@ export import std;
 #include <utility>
 #include <variant>
 #include <vector>
-#include <fstream>
 #if __has_include(<unistd.h>) and __has_include(<sys/wait.h>)
 #include <sys/wait.h>
 #include <unistd.h>
@@ -183,8 +183,8 @@ class function<R(TArgs...)> {
 }
 
 template <class TPattern, class TStr>
-[[nodiscard]] constexpr auto match(const TPattern& pattern, const TStr& str)
-    -> std::vector<TStr> {
+[[nodiscard]] constexpr auto match(const TPattern& pattern,
+                                   const TStr& str) -> std::vector<TStr> {
   std::vector<TStr> groups{};
   auto pi = 0u;
   auto si = 0u;
@@ -237,22 +237,22 @@ template <class T = std::string_view, class TDelim>
   }
   return output;
 }
-constexpr auto regex_match(const char *str, const char *pattern) -> bool {
+constexpr auto regex_match(const char* str, const char* pattern) -> bool {
   if (*pattern == '\0' && *str == '\0') return true;
   if (*pattern == '\0' && *str != '\0') return false;
   if (*str == '\0' && *pattern != '\0') return false;
   if (*pattern == '.') {
-    return regex_match(str+1, pattern+1);
+    return regex_match(str + 1, pattern + 1);
   }
   if (*pattern == *str) {
-    return regex_match(str+1, pattern+1);
+    return regex_match(str + 1, pattern + 1);
   }
   return false;
 }
 }  // namespace utility
 
 namespace reflection {
-#if defined(__cpp_lib_source_location)
+#if defined(__cpp_lib_source_location) && !defined(_LIBCPP_APPLE_CLANG_VER)
 using source_location = std::source_location;
 #else
 class source_location {
@@ -353,8 +353,9 @@ template <class T>
 }
 
 template <class T, class U>
-[[nodiscard]] constexpr auto abs_diff(const T t, const U u)
-    -> decltype(t < u ? u - t : t - u) {
+[[nodiscard]] constexpr auto abs_diff(const T t,
+                                      const U u) -> decltype(t < u ? u - t
+                                                                   : t - u) {
   return t < u ? u - t : t - u;
 }
 
@@ -463,8 +464,8 @@ struct function_traits<R (T::*)(TArgs...) const> {
 template <class T>
 T&& declval();
 template <class... Ts, class TExpr>
-constexpr auto is_valid(TExpr expr)
-    -> decltype(expr(declval<Ts...>()), bool()) {
+constexpr auto is_valid(TExpr expr) -> decltype(expr(declval<Ts...>()),
+                                                bool()) {
   return true;
 }
 template <class...>
@@ -601,7 +602,7 @@ struct suite_end {
 template <class Test, class TArg = none>
 struct test {
   std::string_view type{};
-  std::string name{}; /// might be dynamic
+  std::string name{};  /// might be dynamic
   std::vector<std::string_view> tag{};
   reflection::source_location location{};
   TArg arg{};
@@ -614,8 +615,8 @@ struct test {
   static constexpr auto run_impl(Test test, const none&) { test(); }
 
   template <class T>
-  static constexpr auto run_impl(T test, const TArg& arg)
-      -> decltype(test(arg), void()) {
+  static constexpr auto run_impl(T test, const TArg& arg) -> decltype(test(arg),
+                                                                      void()) {
     test(arg);
   }
 
@@ -1569,9 +1570,8 @@ class reporter {
                << printer_.colors().fail << tests_.fail << " failed"
                << printer_.colors().none << '\n'
                << "asserts: " << (asserts_.pass + asserts_.fail) << " | "
-               << asserts_.pass << " passed"
-               << " | " << printer_.colors().fail << asserts_.fail << " failed"
-               << printer_.colors().none << '\n';
+               << asserts_.pass << " passed" << " | " << printer_.colors().fail
+               << asserts_.fail << " failed" << printer_.colors().none << '\n';
       std::cerr << printer_.str() << std::endl;
     } else {
       std::cout << printer_.colors().pass << "All tests passed"
@@ -1873,16 +1873,18 @@ class reporter_junit {
     std::cout.flush();
     std::cout.rdbuf(cout_save);
     std::ofstream maybe_of;
-    if (detail::cfg::output_filename != "") { maybe_of = std::ofstream(detail::cfg::output_filename); }
+    if (detail::cfg::output_filename != "") {
+      maybe_of = std::ofstream(detail::cfg::output_filename);
+    }
 
     if (report_type_ == JUNIT) {
-      print_junit_summary(detail::cfg::output_filename != "" ? maybe_of : std::cout);
+      print_junit_summary(detail::cfg::output_filename != "" ? maybe_of
+                                                             : std::cout);
       return;
     }
     print_console_summary(
-      detail::cfg::output_filename != "" ? maybe_of : std::cout,
-      detail::cfg::output_filename != "" ? maybe_of : std::cerr
-    );
+        detail::cfg::output_filename != "" ? maybe_of : std::cout,
+        detail::cfg::output_filename != "" ? maybe_of : std::cerr);
   }
 
  protected:
@@ -1898,25 +1900,25 @@ class reporter_junit {
     }
   }
 
-  void print_console_summary(std::ostream &out_stream, std::ostream &err_stream) {
+  void print_console_summary(std::ostream& out_stream,
+                             std::ostream& err_stream) {
     for (const auto& [suite_name, suite_result] : results_) {
       if (suite_result.fails) {
         err_stream
             << "\n========================================================"
                "=======================\n"
-            << "Suite " << suite_name << '\n' //
+            << "Suite " << suite_name << '\n'  //
             << "tests:   " << (suite_result.n_tests) << " | " << color_.fail
             << suite_result.fails << " failed" << color_.none << '\n'
             << "asserts: " << (suite_result.assertions) << " | "
-            << suite_result.passed << " passed"
-            << " | " << color_.fail << suite_result.fails << " failed"
-            << color_.none << '\n';
+            << suite_result.passed << " passed" << " | " << color_.fail
+            << suite_result.fails << " failed" << color_.none << '\n';
         std::cerr << std::endl;
       } else {
         out_stream << color_.pass << "Suite '" << suite_name
-                  << "': all tests passed" << color_.none << " ("
-                  << suite_result.assertions << " asserts in "
-                  << suite_result.n_tests << " tests)\n";
+                   << "': all tests passed" << color_.none << " ("
+                   << suite_result.assertions << " asserts in "
+                   << suite_result.n_tests << " tests)\n";
 
         if (suite_result.skipped) {
           std::cout << suite_result.skipped << " tests skipped\n";
@@ -1927,9 +1929,9 @@ class reporter_junit {
     }
   }
 
-  void print_junit_summary(std::ostream &stream) {
+  void print_junit_summary(std::ostream& stream) {
     // aggregate results
-    size_t n_tests=0, n_fails=0;
+    size_t n_tests = 0, n_fails = 0;
     double total_time = 0.0;
     auto suite_time = [](auto const& suite_result) {
       std::int64_t time_ms =
@@ -1947,11 +1949,11 @@ class reporter_junit {
     // mock junit output:
     stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
     stream << "<testsuites";
-      stream << " name=\"all\"";
-      stream << " tests=\"" << n_tests << '\"';
-      stream << " failures=\"" << n_fails << '\"';
-      stream << " time=\"" << total_time << '\"';
-      stream << ">\n";
+    stream << " name=\"all\"";
+    stream << " tests=\"" << n_tests << '\"';
+    stream << " failures=\"" << n_fails << '\"';
+    stream << " time=\"" << total_time << '\"';
+    stream << ">\n";
 
     for (const auto& [suite_name, suite_result] : results_) {
       stream << "<testsuite";
@@ -1969,8 +1971,8 @@ class reporter_junit {
     }
     stream << "</testsuites>";
   }
-  void print_result(std::ostream &stream, const std::string& suite_name, std::string indent,
-                    const test_result& parent) {
+  void print_result(std::ostream& stream, const std::string& suite_name,
+                    std::string indent, const test_result& parent) {
     for (const auto& [name, result] : *parent.nested_tests) {
       stream << indent;
       stream << "<testcase classname=\"" << result.suite_name << '\"';
@@ -1983,8 +1985,7 @@ class reporter_junit {
           std::chrono::duration_cast<std::chrono::milliseconds>(
               result.run_stop - result.run_start)
               .count();
-      stream << " time=\"" << (static_cast<double>(time_ms) / 1000.0)
-                << "\"";
+      stream << " time=\"" << (static_cast<double>(time_ms) / 1000.0) << "\"";
       stream << " status=\"" << result.status << '\"';
       if (result.report_string.empty() && result.nested_tests->empty()) {
         stream << " />\n";
@@ -2026,8 +2027,8 @@ class runner {
         : path_{utility::split(_filter, delim)} {}
 
     template <class TPath>
-    constexpr auto operator()(const std::size_t level, const TPath& path) const
-        -> bool {
+    constexpr auto operator()(const std::size_t level,
+                              const TPath& path) const -> bool {
       for (auto i = 0u; i < math::min_value(level + 1, std::size(path_)); ++i) {
         if (not utility::is_match(path[i], path_[i])) {
           return false;
@@ -2156,7 +2157,7 @@ class runner {
       }
 #endif
 
-      if (not --level_) {
+      if (not--level_) {
         reporter_.on(events::test_end{.type = test.type, .name = test.name});
       } else {  // N.B. prev. only root-level tests were signalled on finish
         if constexpr (requires {
@@ -2742,20 +2743,18 @@ template <class F, class T,
 [[nodiscard]] constexpr auto operator|(const F& f, const T& t) {
   return [f, t](const auto name) {
     for (const auto& arg : t) {
-      detail::on<F>(events::test<F, decltype(arg)>{
-              .type = "test",
-              .name = std::string{name},
-              .tag = {},
-              .location = {},
-              .arg = arg,
-              .run = f});
+      detail::on<F>(events::test<F, decltype(arg)>{.type = "test",
+                                                   .name = std::string{name},
+                                                   .tag = {},
+                                                   .location = {},
+                                                   .arg = arg,
+                                                   .run = f});
     }
   };
 }
 
-template <
-    class F, template <class...> class T, class... Ts,
-    type_traits::requires_t<not type_traits::is_range_v<T<Ts...>>> = 0>
+template <class F, template <class...> class T, class... Ts,
+          type_traits::requires_t<not type_traits::is_range_v<T<Ts...>>> = 0>
 [[nodiscard]] constexpr auto operator|(const F& f, const T<Ts...>& t) {
   return [f, t](const auto name) {
     apply(
@@ -3329,8 +3328,8 @@ using operators::operator>>;
 
 #if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
     !defined(__EMSCRIPTEN__)
-__attribute__((constructor(101))) inline void cmd_line_args(int argc,
-                                                       const char* argv[]) {
+__attribute__((constructor(101))) inline void cmd_line_args(
+    int argc, const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;
   ::boost::ut::detail::cfg::largv = argv;
 }
@@ -3339,8 +3338,8 @@ __attribute__((constructor(101))) inline void cmd_line_args(int argc,
 #endif
 
 #if defined(_MSC_VER)
-  #pragma pop_macro("min")
-  #pragma pop_macro("max")
+#pragma pop_macro("min")
+#pragma pop_macro("max")
 #endif
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if(TEST_INSTALLED_VERSION)
     set(CMAKE_CXX_EXTENSIONS NO)
   endif()
 
-  find_package(ut 1.1 REQUIRED)
+  find_package(ut REQUIRED)
   include(../cmake/AddCustomCommandOrTest.cmake)
 
   enable_testing()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,8 +10,14 @@ project(boost.ut.test LANGUAGES CXX)
 if(TEST_INSTALLED_VERSION)
   if(NOT DEFINED CMAKE_CXX_STANDARD)
     option(CXX_STANDARD_REQUIRED "Require c++ standard" YES)
-    set(CMAKE_CXX_STANDARD 20)
-    set(CMAKE_CXX_EXTENSIONS NO)
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+      set(CMAKE_CXX_STANDARD
+          20
+          CACHE STRING "Default value for CXX_STANDARD property of targets."
+      )
+      option(CMAKE_CXX_STANDARD_REQUIRED "Default value for CXX_STANDARD_REQUIRED property of targets." YES)
+      option(CMAKE_CXX_EXTENSIONS "Default value for CXX_EXTENSIONS property of targets." NO)
+    endif()
   endif()
 
   find_package(ut REQUIRED)

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,8 @@
+# run this from project directory
+rm -rf ./{build,build2,install_dir}
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_QUIET=OFF --log-level=DEBUG -DBOOST_UT_ENABLE_INSTALL=1
+cmake --build ./build/ -j24 --verbose
+cmake --install ./build/ --prefix ./install_dir
+CMAKE_PREFIX_PATH=./install_dir/ cmake -Stest -Bbuild2 -DTEST_INSTALLED_VERSION=1 -DCPM_SOURCE_CACHE=~/.cache/cpm --log-level=DEBUG
+
+

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # run this from project directory
 rm -rf ./{build,build2,install_dir}
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_QUIET=OFF --log-level=DEBUG -DBOOST_UT_ENABLE_INSTALL=1

--- a/test/test_download_all.sh
+++ b/test/test_download_all.sh
@@ -1,0 +1,7 @@
+# run this from project directory
+rm -rf ./{build,build2,install_dir}
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_QUIET=OFF -DCPM_DOWNLOAD_ALL=1 --log-level=DEBUG -DBOOST_UT_ENABLE_INSTALL=1
+cmake --build ./build/ -j24 --verbose
+cmake --install ./build/ --prefix ./install_dir
+CMAKE_PREFIX_PATH=./install_dir/ cmake -Stest -Bbuild2 -DTEST_INSTALLED_VERSION=1 -DCPM_DOWNLOAD_ALL=1 --log-level=DEBUG
+

--- a/test/test_download_all.sh
+++ b/test/test_download_all.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # run this from project directory
 rm -rf ./{build,build2,install_dir}
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_QUIET=OFF -DCPM_DOWNLOAD_ALL=1 --log-level=DEBUG -DBOOST_UT_ENABLE_INSTALL=1


### PR DESCRIPTION
Problem:
Install, enscriptem and macos pipelines were failing. 

Install because there was `find_package(ut )` with specific old version if BOOST_UT_TEST_INSTALLED_VERSION at `test/CMakeLists.txt`. 

enscriptem because there was ask specific ask for `set(CMAKE_CXX_STANDARD 20)` at `test/CMakeLists.txt` and there was an example that could not be compiled. I've fixed cmake and wrapped with macro the failing part of the example

macos was failing because it couldn't install pyyaml. After my friend at live through discord tried to reproduce and made mistake, it was found out that `pipx install pyaml` works, but `pipx install pyyaml` doesn't work. IDK why. Though, there's test fail at macos pipeline, and a guy said it's because source_location is broken on macos.

Also there was some bad docstring for BOOST_UT_ENABLE_SANITIZERS .

Also added two `.sh` scripts at tests for easy checking of installed version.

Also all cmake commands at pipelines now produce more verbose output and some commands parallelized at -j4 .

maybe review, please
@krzysztof-jusiak 