### PR TITLE
Typo fixes in README.md and ut.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,12 +1497,12 @@ namespace boost::inline ext::ut::inline v2_1_0 {
      * Explicitly runs registered test suites
      * If not called directly test suites are executed with run's destructor
      * @example return run({.report_errors = true})
-     * @param run_cfg.report_errors {default: false} if true it prints the summary after runnig
+     * @param run_cfg.report_errors {default: false} if true it prints the summary after running
      */
     auto run(run_cfg);
 
     /**
-     * Runs registered test suites if they haven't been explicilty executed already
+     * Runs registered test suites if they haven't been explicitly executed already
      */
     ~run();
   };
@@ -1624,7 +1624,7 @@ namespace boost::inline ext::ut::inline v2_1_0 {
 
   ```cpp
   /**
-   * Reperesents suite object
+   * Represents suite object
    * @example suite _ = []{};
    */
   struct suite final {
@@ -1722,14 +1722,14 @@ namespace boost::inline ext::ut::inline v2_1_0 {
   /**
    * Comparison Operator
    */
-  template <Operator TLhs, Opeartor TRhs>
+  template <Operator TLhs, Operator TRhs>
   struct eq final {
     TLhs lhs{}; // Left-hand side operator
     TRhs rhs{}; // Right-hand side operator
 
     /**
-     * Performs comparison operatation
-     * @return true if expression is succesful
+     * Performs comparison operation
+     * @return true if expression is successful
      */
     [[nodiscard]] constexpr explicit operator bool() const {
       return lhs == rhs;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -105,7 +105,7 @@ export import std;
 #include <source_location>
 #endif
 
-struct unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct_ {
+struct unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_ {
 };
 
 BOOST_UT_EXPORT
@@ -298,29 +298,29 @@ template <typename TargetType>
 
 inline constexpr const std::string_view raw_type_name =
     get_template_function_name_use_decay_type<
-        unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct_>();
+        unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_>();
 
 inline constexpr const std::size_t raw_length = raw_type_name.length();
 inline constexpr const std::string_view need_name =
 #if defined(_MSC_VER) and not defined(__clang__)
     "struct "
-    "unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct_";
+    "unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_";
 #else
-    "unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct_";
+    "unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_";
 #endif
 inline constexpr const std::size_t need_length = need_name.length();
 static_assert(need_length <= raw_length,
-              "Auto find prefix and suffix lenght broken error 1");
+              "Auto find prefix and suffix length broken error 1");
 inline constexpr const std::size_t prefix_length =
     raw_type_name.find(need_name);
 static_assert(prefix_length != std::string_view::npos,
-              "Auto find prefix and suffix lenght broken error 2");
+              "Auto find prefix and suffix length broken error 2");
 static_assert(prefix_length <= raw_length,
-              "Auto find prefix and suffix lenght broken error 3");
-inline constexpr const std::size_t tail_lenght = raw_length - prefix_length;
-static_assert(need_length <= tail_lenght,
-              "Auto find prefix and suffix lenght broken error 4");
-inline constexpr const std::size_t suffix_length = tail_lenght - need_length;
+              "Auto find prefix and suffix length broken error 3");
+inline constexpr const std::size_t tail_length = raw_length - prefix_length;
+static_assert(need_length <= tail_length,
+              "Auto find prefix and suffix length broken error 4");
+inline constexpr const std::size_t suffix_length = tail_length - need_length;
 
 }  // namespace detail
 


### PR DESCRIPTION
Problem:
- While building my project with codespell, I found some typos in the files README.md and ut.hpp

Solution:
- Typo fixes found by the codespell utility have been provided

Issue: #

Reviewers:
@krzysztof-jusiak
