### PR TITLE
fix(cmake): CMP0175

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(BOOST_UT_USE_WARNINGS_AS_ERORS)
 endif()
 
 add_custom_target(style)
-add_custom_command(
+add_custom_command(POST_BUILD
   TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include
                        ${CMAKE_CURRENT_LIST_DIR}/test -iname "*.hpp" -or -iname "*.cpp" | xargs clang-format -i
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ endif()
 
 add_custom_target(style)
 add_custom_command(
-  TARGET style POST_BUILD COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include
-                       ${CMAKE_CURRENT_LIST_DIR}/test -iname "*.hpp" -or -iname "*.cpp" | xargs clang-format -i
+  TARGET style
+  POST_BUILD
+  COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include
+          ${CMAKE_CURRENT_LIST_DIR}/test -iname "*.hpp" -or -iname "*.cpp" | xargs clang-format -i
 )
 
 if(BOOST_UT_ENABLE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ if(BOOST_UT_USE_WARNINGS_AS_ERORS)
 endif()
 
 add_custom_target(style)
-add_custom_command(POST_BUILD
-  TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include
+add_custom_command(
+  TARGET style POST_BUILD COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include
                        ${CMAKE_CURRENT_LIST_DIR}/test -iname "*.hpp" -or -iname "*.cpp" | xargs clang-format -i
 )
 

--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -13,7 +13,7 @@ function(ut_add_custom_command_or_test)
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
-    add_custom_command(TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
+    add_custom_command(POST_BUILD TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
   else()
     add_test(NAME ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
   endif()

--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -13,7 +13,7 @@ function(ut_add_custom_command_or_test)
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
-    add_custom_command(POST_BUILD TARGET ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
+    add_custom_command(TARGET ${PARSE_TARGET} POST_BUILD COMMAND ${PARSE_COMMAND})
   else()
     add_test(NAME ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
   endif()

--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -13,7 +13,11 @@ function(ut_add_custom_command_or_test)
   target_link_libraries(${PARSE_TARGET} PRIVATE Boost::ut)
 
   if(BOOST_UT_ENABLE_RUN_AFTER_BUILD)
-    add_custom_command(TARGET ${PARSE_TARGET} POST_BUILD COMMAND ${PARSE_COMMAND})
+    add_custom_command(
+      TARGET ${PARSE_TARGET}
+      POST_BUILD
+      COMMAND ${PARSE_COMMAND}
+    )
   else()
     add_test(NAME ${PARSE_TARGET} COMMAND ${PARSE_COMMAND})
   endif()


### PR DESCRIPTION
Problem:

CMake 3.31 now rejects `add_custom_command` with invalid arguments ([CMP0175](https://cmake.org/cmake/help/latest/policy/CMP0175.html))

Solution:

Specify `POST_BUILD` in all add_custom_command calls.

Issue: <None>

Reviewers:
@kris-jusiak 
