### PR TITLE
fix clang-tidy-19 problems

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,6 @@ readability-*,\
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 User:            clausklein
 ...

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -822,7 +822,7 @@ struct cfg {
     }
     query_pattern = "";
     bool found_first_option = false;
-    for (auto i = 1U; i < n_args; i++) {
+    for (auto i = 1U; i < n_args && argv != nullptr; i++) {
       std::string cmd(argv[i]);
       auto cmd_option = find_arg(cmd);
       if (!cmd_option.has_value()) {


### PR DESCRIPTION
Problem:
- the `AnalyzeTemporaryDtors` options has been removed from [clang-tidy-18](https://github.com/llvm/llvm-project/issues/62020) 
- `parse()` triggers `clang-analyzer-core.NullDereference` from clang-tidy-19

Solution:
- remove 'AnalyzeTemporaryDtors' from .clang-tidy,
- add `argv != nullptr` checking in `parse()`.

Issue: #

Reviewers:
@
