### PR TITLE
Improve BDD test output

### DIFF
--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -1,4 +1,4 @@
-option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" OFF)
+option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" ON)
 
 function(ut_add_custom_command_or_test)
   # Define the supported set of keywords

--- a/cmake/AddCustomCommandOrTest.cmake
+++ b/cmake/AddCustomCommandOrTest.cmake
@@ -1,4 +1,4 @@
-option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" ON)
+option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" OFF)
 
 function(ut_add_custom_command_or_test)
   # Define the supported set of keywords

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1787,7 +1787,7 @@ class reporter_junit {
     if (report_type_ == CONSOLE) {
       ss_out_ << "\n";
       ss_out_ << std::string(2 * active_test_.size() - 2, ' ');
-      ss_out_ << "Running test \"" << test_event.name << "\"... ";
+      ss_out_ << "Running " << test_event.type << " \"" << test_event.name << "\"... ";
     }
   }
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2760,9 +2760,9 @@ template <class F, class T>
 {
   return [f, t](const auto name) {
     for (int counter = 1; const auto& arg : t) {
-      const auto unique_name =
-          std::string{name} + std::format(" ({}{} parameter)", counter,
-                                          get_ordinal_suffix(counter));
+      const auto unique_name = std::string{name} + " (" +
+                               std::to_string(counter) +
+                               get_ordinal_suffix(counter) + " parameter)";
       detail::on<F>(events::test<F, decltype(arg)>{.type = "test",
                                                    .name = unique_name,
                                                    .tag = {},
@@ -2779,14 +2779,11 @@ template <class F, template <class...> class T, class... Ts>
   requires (!std::ranges::range<T<Ts...>>)
 {
   constexpr auto unique_name = []<class TArg>(const auto& name, int& counter) {
-    auto ret = std::string{name};
+    auto ret = std::string{name} + " (";
     if (std::invocable<F, TArg>) {
-      ret += std::format(" ({}{} parameter, {})", counter,
-                         get_ordinal_suffix(counter),
-                         reflection::type_name<TArg>());
-    } else {
-      ret += std::format(" ({})", reflection::type_name<TArg>());
+      ret += std::to_string(counter) + get_ordinal_suffix(counter) + " parameter, ";
     }
+    ret += std::string(reflection::type_name<TArg>()) + ")";
     ++counter;
     return ret;
   };

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1025,7 +1025,12 @@ struct eq_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value == rhs.value;
+#else
             return TLhs::value == TRhs::value;
+#endif
           } else if constexpr (type_traits::has_static_member_object_epsilon_v<
                                    TLhs> and
                                type_traits::has_static_member_object_epsilon_v<
@@ -1090,7 +1095,13 @@ struct neq_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value != rhs.value;
+#else
             return TLhs::value != TRhs::value;
+#endif
+
           } else if constexpr (type_traits::has_static_member_object_epsilon_v<
                                    TLhs> and
                                type_traits::has_static_member_object_epsilon_v<
@@ -1125,7 +1136,13 @@ struct gt_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value > rhs.value;
+#else
             return TLhs::value > TRhs::value;
+#endif
+
           } else {
             return get(lhs_) > get(rhs_);
           }
@@ -1148,7 +1165,13 @@ struct ge_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value >= rhs.value;
+#else
             return TLhs::value >= TRhs::value;
+#endif
+
           } else {
             return get(lhs_) >= get(rhs_);
           }
@@ -1171,7 +1194,12 @@ struct lt_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value < rhs.value;
+#else
             return TLhs::value < TRhs::value;
+#endif
           } else {
             return get(lhs_) < get(rhs_);
           }
@@ -1195,7 +1223,13 @@ struct le_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC
+            return lhs.value <= rhs.value;
+#else
             return TLhs::value <= TRhs::value;
+#endif
+
           } else {
             return get(lhs_) <= get(rhs_);
           }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1535,22 +1535,26 @@ int main() {
 
       "args vector"_test = [](const auto& arg) {
         expect(arg > 0_i) << "all values greater than 0";
-      } | std::vector{1, 2, 3};
+      } | std::vector{1, 2, 3, 4};
 
-      test_assert(3 == std::size(test_cfg.run_calls));
-      test_assert("args vector"sv == test_cfg.run_calls[0].name);
+      test_assert(4 == std::size(test_cfg.run_calls));
+      test_assert("args vector (1st parameter)"sv == test_cfg.run_calls[0].name);
       test_assert(1 == std::any_cast<int>(test_cfg.run_calls[0].arg));
-      test_assert("args vector"sv == test_cfg.run_calls[1].name);
+      test_assert("args vector (2nd parameter)"sv == test_cfg.run_calls[1].name);
       test_assert(2 == std::any_cast<int>(test_cfg.run_calls[1].arg));
-      test_assert("args vector"sv == test_cfg.run_calls[2].name);
+      test_assert("args vector (3rd parameter)"sv == test_cfg.run_calls[2].name);
       test_assert(3 == std::any_cast<int>(test_cfg.run_calls[2].arg));
-      test_assert(3 == std::size(test_cfg.assertion_calls));
+      test_assert("args vector (4th parameter)"sv == test_cfg.run_calls[3].name);
+      test_assert(3 == std::any_cast<int>(test_cfg.run_calls[2].arg));
+      test_assert(4 == std::size(test_cfg.assertion_calls));
       test_assert(test_cfg.assertion_calls[0].result);
       test_assert("1 > 0" == test_cfg.assertion_calls[0].expr);
       test_assert(test_cfg.assertion_calls[1].result);
       test_assert("2 > 0" == test_cfg.assertion_calls[1].expr);
       test_assert(test_cfg.assertion_calls[2].result);
       test_assert("3 > 0" == test_cfg.assertion_calls[2].expr);
+      test_assert(test_cfg.assertion_calls[3].result);
+      test_assert("4 > 0" == test_cfg.assertion_calls[3].expr);
     }
 
     {
@@ -1561,9 +1565,9 @@ int main() {
       } | std::array{99, 11};
 
       test_assert(2 == std::size(test_cfg.run_calls));
-      test_assert("args array"sv == test_cfg.run_calls[0].name);
+      test_assert("args array (1st parameter)"sv == test_cfg.run_calls[0].name);
       test_assert(99 == std::any_cast<int>(test_cfg.run_calls[0].arg));
-      test_assert("args array"sv == test_cfg.run_calls[1].name);
+      test_assert("args array (2nd parameter)"sv == test_cfg.run_calls[1].name);
       test_assert(11 == std::any_cast<int>(test_cfg.run_calls[1].arg));
       test_assert(2 == std::size(test_cfg.assertion_calls));
       test_assert(test_cfg.assertion_calls[0].result);
@@ -1580,11 +1584,11 @@ int main() {
       } | std::string{"str"};
 
       test_assert(3 == std::size(test_cfg.run_calls));
-      test_assert("args string"sv == test_cfg.run_calls[0].name);
+      test_assert("args string (1st parameter)"sv == test_cfg.run_calls[0].name);
       test_assert('s' == std::any_cast<char>(test_cfg.run_calls[0].arg));
-      test_assert("args string"sv == test_cfg.run_calls[1].name);
+      test_assert("args string (2nd parameter)"sv == test_cfg.run_calls[1].name);
       test_assert('t' == std::any_cast<char>(test_cfg.run_calls[1].arg));
-      test_assert("args string"sv == test_cfg.run_calls[2].name);
+      test_assert("args string (3rd parameter)"sv == test_cfg.run_calls[2].name);
       test_assert('r' == std::any_cast<char>(test_cfg.run_calls[2].arg));
       test_assert(3 == std::size(test_cfg.assertion_calls));
       test_assert(test_cfg.assertion_calls[0].result);
@@ -1608,11 +1612,11 @@ int main() {
       } | std::map<char, int>{{'a', 1}, {'b', 2}};
 
       test_assert(2 == std::size(test_cfg.run_calls));
-      test_assert("args map"sv == test_cfg.run_calls[0].name);
+      test_assert("args map (1st parameter)"sv == test_cfg.run_calls[0].name);
       test_assert(
           std::pair<const char, int>{'a', 1} ==
           std::any_cast<std::pair<const char, int>>(test_cfg.run_calls[0].arg));
-      test_assert("args map"sv == test_cfg.run_calls[1].name);
+      test_assert("args map (2nd parameter)"sv == test_cfg.run_calls[1].name);
       test_assert(
           std::pair<const char, int>{'b', 2} ==
           std::any_cast<std::pair<const char, int>>(test_cfg.run_calls[1].arg));
@@ -1638,11 +1642,11 @@ int main() {
       } | std::tuple<bool, int, void*>{};
 
       test_assert(3 == std::size(test_cfg.run_calls));
-      test_assert("types"sv == test_cfg.run_calls[0].name);
+      test_assert("types (bool)"sv == test_cfg.run_calls[0].name);
       void(std::any_cast<bool>(test_cfg.run_calls[0].arg));
-      test_assert("types"sv == test_cfg.run_calls[1].name);
+      test_assert("types (int)"sv == test_cfg.run_calls[1].name);
       void(std::any_cast<int>(test_cfg.run_calls[1].arg));
-      test_assert("types"sv == test_cfg.run_calls[2].name);
+      test_assert("types (void *)"sv == test_cfg.run_calls[2].name);
       void(std::any_cast<void*>(test_cfg.run_calls[2].arg));
       test_assert(3 == std::size(test_cfg.assertion_calls));
       test_assert("(true or void == bool)" == test_cfg.assertion_calls[0].expr);
@@ -1663,9 +1667,9 @@ int main() {
       } | std::tuple{42, 'x'};
 
       test_assert(2 == std::size(test_cfg.run_calls));
-      test_assert("args and types"sv == test_cfg.run_calls[0].name);
+      test_assert("args and types (1st parameter, int)"sv == test_cfg.run_calls[0].name);
       test_assert(42 == std::any_cast<int>(test_cfg.run_calls[0].arg));
-      test_assert("args and types"sv == test_cfg.run_calls[1].name);
+      test_assert("args and types (2nd parameter, char)"sv == test_cfg.run_calls[1].name);
       test_assert('x' == std::any_cast<char>(test_cfg.run_calls[1].arg));
       test_assert(4 == std::size(test_cfg.assertion_calls));
       test_assert(test_cfg.assertion_calls[0].result);

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1646,7 +1646,8 @@ int main() {
       void(std::any_cast<bool>(test_cfg.run_calls[0].arg));
       test_assert("types (int)"sv == test_cfg.run_calls[1].name);
       void(std::any_cast<int>(test_cfg.run_calls[1].arg));
-      test_assert("types (void *)"sv == test_cfg.run_calls[2].name);
+      // the pointer is printed differently on different platforms, so we only check the prefix
+      test_assert(test_cfg.run_calls[2].name.starts_with("types (void"));
       void(std::any_cast<void*>(test_cfg.run_calls[2].arg));
       test_assert(3 == std::size(test_cfg.assertion_calls));
       test_assert("(true or void == bool)" == test_cfg.assertion_calls[0].expr);


### PR DESCRIPTION
**Problem:**
Currently, when the test output is printed, it only uses the test name, but not the test type. For the BDD test example from the README (modified to make it fail: https://godbolt.org/z/1T6bnzcez):

```c++
int main() {
  using namespace boost::ut;
  using namespace boost::ut::bdd;

  "vector"_test = [] {
    given("I have a vector") = [] {
      std::vector<int> v(5);
      expect((5_ul == std::size(v)) >> fatal);

      when("I resize bigger") = [=] {
        mut(v).resize(10);

        then("The size should increase") = [=] {
          expect(9_ul == std::size(v));
        };
      };
    };
  };
}
```
the output looks like this:
```
Running test "vector"... 
  Running test "I have a vector"... 
    Running test "I resize bigger"... 
      Running test "The size should increase"... FAILED
in: /app/example.cpp:17 - test condition:  [9 == 10]
```
Not that though we used `given`, `when`, `then`, the output always is the same (`"Running test 'test name'"`) and does not reflect the BDD test structure.

**Solution:**
Include the test type in the test output. With this PR, the output becomes

```
Running test "vector"... 
  Running given "I have a vector"... 
    Running when "I resize bigger"... 
      Running then "The size should increase"... FAILED
```

This PR is based on #656 (to include the CI fixes from that PR), the only actual change in this PR is 41013d866bc8d665e6808e10b30600af67dedeb3.