### PR TITLE
Add test for issue number 581

### DIFF
--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1732,6 +1732,29 @@ int main() { // NOLINT(readability-function-size)
     }
 
     {
+      // See https://github.com/boost-ext/ut/issues/581
+      test_cfg = fake_cfg{};
+      test("count asserts using operator|") = []() {
+        test("MyTest") = [](auto fixture) {
+          expect(fixture > 0);
+          expect(false);
+        } | std::vector{1, 2, 3, 4};
+      };
+      test_assert(test_cfg.assertion_calls.size() == 8);
+
+      test_cfg = fake_cfg{};
+      test("count asserts using for") = []() {
+        for (auto fixture : std::vector{1, 2, 3, 4}) {
+          test("MyTest" + std::to_string(fixture)) = [&fixture]() {
+            expect(fixture > 0);
+            expect(false);
+          };
+        }
+      };
+      test_assert(test_cfg.assertion_calls.size() == 8);
+    }
+
+    {
       test_cfg = fake_cfg{};
 
       using namespace ut::bdd;


### PR DESCRIPTION
Problem:
In #581 it was reported that the number of assertions differ in parameterized tests using a `for` loop vs `operator|`.

Solution:
The underlying issue was fixed by #640 but this PR adds a test to ensure that the issue does not occur again.

Issue: #581 