### PR TITLE
Use concepts instead of SFINAE

### DIFF
--- a/example/matcher.cpp
+++ b/example/matcher.cpp
@@ -11,7 +11,7 @@
 #include <tuple>
 #include <type_traits>
 
-class matcher : boost::ut::detail::op {
+class matcher : public boost::ut::detail::op {
  public:
   matcher(bool result, const std::string& str) : result_{result}, str_{str} {}
   constexpr explicit operator bool() const { return result_; }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -464,28 +464,12 @@ struct function_traits<R (T::*)(TArgs...) const> {
   using args = list<TArgs...>;
 };
 
-template <class T>
-T&& declval();
-template <class... Ts, class TExpr>
-constexpr auto is_valid(TExpr expr) -> decltype(expr(declval<Ts...>()),
-                                                bool()) {
-  return true;
-}
-template <class...>
-constexpr auto is_valid(...) -> bool {
-  return false;
-}
-
-template <class T>
-inline constexpr auto has_user_print = is_valid<T>(
-    [](auto t) -> decltype(void(declval<std::ostringstream&>() << t)) {});
-
 template <class T, class = void>
 struct has_static_member_object_value : std::false_type {};
 
 template <class T>
 struct has_static_member_object_value<T,
-                                      std::void_t<decltype(declval<T>().value)>>
+                                      std::void_t<decltype(std::declval<T>().value)>>
     : std::bool_constant<!std::is_member_pointer_v<decltype(&T::value)> &&
                          !std::is_function_v<decltype(T::value)>> {};
 
@@ -498,7 +482,7 @@ struct has_static_member_object_epsilon : std::false_type {};
 
 template <class T>
 struct has_static_member_object_epsilon<
-    T, std::void_t<decltype(declval<T>().epsilon)>>
+    T, std::void_t<decltype(std::declval<T>().epsilon)>>
     : std::bool_constant<!std::is_member_pointer_v<decltype(&T::epsilon)> &&
                          !std::is_function_v<decltype(T::epsilon)>> {};
 
@@ -2312,7 +2296,7 @@ struct test {
   template <class Test>
     requires(!std::convertible_to<Test, void (*)(std::string_view)>)
   constexpr auto operator=(Test _test)
-      -> decltype(_test(type_traits::declval<std::string_view>())) {
+      -> decltype(_test(std::declval<std::string_view>())) {
     return _test(name);
   }
 };

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -508,6 +508,23 @@ inline constexpr bool has_static_member_object_epsilon_v =
 
 }  // namespace type_traits
 
+namespace concepts
+{
+
+// std::convertible_to also requires implicit conversion to work
+// See https://stackoverflow.com/a/76547623
+template <class From, class To>
+concept explicitly_convertible_to = requires {
+    static_cast<To>(std::declval<From>());
+};
+
+template <class T>
+concept ostreamable = requires(std::ostringstream& os, T t) {
+  os << t;
+};
+
+} // namespace concepts
+
 template <typename CharT, std::size_t SIZE>
 struct fixed_string {
   constexpr static std::size_t N = SIZE;
@@ -1345,7 +1362,7 @@ class printer {
   }
 
   template <class T>
-    requires std::ranges::range<T> && (!type_traits::has_user_print<T>)
+    requires std::ranges::range<T> && (!concepts::ostreamable<T>)
   auto& operator<<(T&& t) {
     *this << '{';
     auto first = true;
@@ -3006,7 +3023,7 @@ constexpr auto operator not(const T& t) {
 }  // namespace operators
 
 template <class TExpr>
-  requires type_traits::is_op<TExpr> || std::convertible_to<TExpr, bool>
+  requires type_traits::is_op<TExpr> || concepts::explicitly_convertible_to<TExpr, bool>
 constexpr auto expect(const TExpr& expr,
                       const reflection::source_location& sl =
                           reflection::source_location::current()) {

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -433,18 +433,6 @@ int main() { // NOLINT(readability-function-size)
     }
 
     {
-      struct foo {
-        int value;
-      };
-      struct bar {};
-      constexpr auto value = [](auto t) -> decltype(t.value, void()) {};
-      static_assert(type_traits::is_valid<foo>(value));
-      static_assert(not type_traits::is_valid<bar>(value));
-      static_assert(not type_traits::is_valid<int>(value));
-      static_assert(not type_traits::is_valid<void>(value));
-    }
-
-    {
       static_assert("void" == reflection::type_name<void>());
       static_assert("int" == reflection::type_name<int>());
 

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -445,18 +445,6 @@ int main() { // NOLINT(readability-function-size)
     }
 
     {
-      struct foo {};
-      static_assert(type_traits::is_range_v<std::vector<int>>);
-      static_assert(type_traits::is_range_v<std::array<bool, 0>>);
-      static_assert(type_traits::is_range_v<std::string>);
-      static_assert(type_traits::is_range_v<std::string_view>);
-      static_assert(type_traits::is_range_v<std::map<int, int>>);
-      static_assert(not type_traits::is_range_v<int>);
-      static_assert(not type_traits::is_range_v<foo>);
-      static_assert(not type_traits::is_range_v<void>);
-    }
-
-    {
       static_assert("void" == reflection::type_name<void>());
       static_assert("int" == reflection::type_name<int>());
 


### PR DESCRIPTION
Problem:
Since C++17 was used initially, ut uses a custom implementation of concepts. 

Solution:
Since ut now uses C++20, we can use the actual concepts.
