### PR TITLE
Improve parameterized BDD tests

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -882,8 +882,8 @@ template <class T>
 template <class T>
 struct type_ : op {
   template <class TOther>
-  [[nodiscard]] constexpr auto operator()(
-      const TOther&) const  // NOLINT(readability-const-return-type)
+  // NOLINTNEXTLINE(readability-const-return-type)
+  [[nodiscard]] constexpr auto operator()(const TOther&) const
       -> const type_<TOther> {
     return {};
   }


### PR DESCRIPTION
Problem:
The problem I tried to fix in #657 is still not fixed for parameterized tests.

Solution:
Do not unconditionally set the parameterized tests' type to `"test"` but pass the actual test type.
