### PR TITLE
Fix ull->size_t conversion warning

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -820,7 +820,7 @@ struct cfg {
         // parse size argument
         std::size_t last;
         std::string argument(argv[i]);
-        std::size_t val = std::stoull(argument, &last);
+        auto val = static_cast<std::size_t>(std::stoull(argument, &last));
         if (last != argument.length()) {
           std::cerr << "cannot parse option of " << argv[i - 1] << " "
                     << argv[i] << std::endl;


### PR DESCRIPTION
Problem:
-
detected via the 'warning-as-error' flag:
On many architectures `unsigned long long' is identical to 'std::size_t` but not, for example, on all x86_32, WASM, some MSVC versions.

Solution:
-

explicit `static_cast<std::size_t>(..)`.