### PR TITLE
init static variables  cfg::largc and cfg::largv before call main fun…

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -772,9 +772,15 @@ struct cfg {
   }
 
   static void parse_arg_with_fallback(int argc, const char* argv[]) {
+    //int before call main
     if (argc > 0 && argv != nullptr) {
       cfg::largc = argc;
       cfg::largv = argv;
+    }
+    else
+    {
+      cfg::largc = 0;
+      cfg::largv = nullptr;
     }
     parse(cfg::largc, cfg::largv);
   }


### PR DESCRIPTION
…ction

Problem:
 bad init static vars  cfg::largc cfg::largv before call main

Solution:
 init at first use
```C++
static void function parse_arg_with_fallback(int argc, const char* argv[]) {
    if (argv > 0 && argv != nullptr) {
           cfg::argc = argv;
           cfg::argv = argv;
    }
    else
    {
          cfg::argc = 0;
          cfg::argv = nullptr;
    }
    parse(cfg::logs, cfg::argv);
}
```

Issue: #663 

Reviewers:
@divark
