### PR TITLE
separate .cppm file for cxx modules (closes #669)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
+option(BOOST_UT_DISABLE_MODULE "Disable ut module" ON)
 
-if(!BOOST_UT_DISABLE_MODULE)
+if(NOT BOOST_UT_DISABLE_MODULE)
 cmake_minimum_required(VERSION 4.0.0)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "a9e1cf81-9932-4810-974b-6eccaf14e457")
@@ -39,12 +39,12 @@ option(BOOST_UT_ENABLE_INSTALL "Enable install targets" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_USE_WARNINGS_AS_ERORS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
 
 add_library(ut INTERFACE)
-if(!BOOST_UT_DISABLE_MODULE)
+if(NOT BOOST_UT_DISABLE_MODULE)
 add_library(ut_module)
 endif()
 target_include_directories(ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_compile_features(ut INTERFACE cxx_std_20)
-if(!BOOST_UT_DISABLE_MODULE)
+if(NOT BOOST_UT_DISABLE_MODULE)
 target_compile_features(ut_module INTERFACE cxx_std_23)
 endif()
 
@@ -76,7 +76,7 @@ if(BOOST_UT_DISABLE_MODULE)
   target_compile_definitions(ut INTERFACE BOOST_UT_DISABLE_MODULE)
 endif()
 
-if(!BOOST_UT_DISABLE_MODULE)
+if(NOT BOOST_UT_DISABLE_MODULE)
 target_sources(ut_module PUBLIC FILE_SET CXX_MODULES FILES include/boost/ut.cppm)
 endif()
 
@@ -84,7 +84,7 @@ if(NOT TARGET Boost::ut)
   add_library(Boost::ut ALIAS ut)
 endif()
 
-if(!BOOST_UT_DISABLE_MODULE)
+if(NOT BOOST_UT_DISABLE_MODULE)
 add_library(Boost::ut_module ALIAS ut_module)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,16 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
+option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
+
+if(!BOOST_UT_DISABLE_MODULE)
+cmake_minimum_required(VERSION 4.0.0)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "a9e1cf81-9932-4810-974b-6eccaf14e457")
+set(CMAKE_CXX_MODULE_STD 1)
+else()
 cmake_minimum_required(VERSION 3.21...3.25)
+endif()
 project(
   ut
   VERSION 2.3.0
@@ -28,11 +37,16 @@ option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_BUILD_TESTS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_ENABLE_INSTALL "Enable install targets" ${PROJECT_IS_TOP_LEVEL})
 option(BOOST_UT_USE_WARNINGS_AS_ERORS "Build the tests" ${PROJECT_IS_TOP_LEVEL})
-option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
 
 add_library(ut INTERFACE)
+if(!BOOST_UT_DISABLE_MODULE)
+add_library(ut_module)
+endif()
 target_include_directories(ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_compile_features(ut INTERFACE cxx_std_20)
+if(!BOOST_UT_DISABLE_MODULE)
+target_compile_features(ut_module INTERFACE cxx_std_23)
+endif()
 
 if(BOOST_UT_USE_WARNINGS_AS_ERORS)
   include(cmake/WarningsAsErrors.cmake)
@@ -62,15 +76,23 @@ if(BOOST_UT_DISABLE_MODULE)
   target_compile_definitions(ut INTERFACE BOOST_UT_DISABLE_MODULE)
 endif()
 
+if(!BOOST_UT_DISABLE_MODULE)
+target_sources(ut_module PUBLIC FILE_SET CXX_MODULES FILES include/boost/ut.cppm)
+endif()
+
 if(NOT TARGET Boost::ut)
   add_library(Boost::ut ALIAS ut)
+endif()
+
+if(!BOOST_UT_DISABLE_MODULE)
+add_library(Boost::ut_module ALIAS ut_module)
 endif()
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 install(
-  FILES include/boost/ut.hpp
+  FILES include/boost/ut.hpp include/boost/ut.cppm
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/boost
 )
 

--- a/include/boost/ut.cppm
+++ b/include/boost/ut.cppm
@@ -1,0 +1,14 @@
+module;
+
+#if __has_include(<unistd.h>) and __has_include(<sys/wait.h>)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+export module boost.ut;
+export import std;
+
+#define BOOST_UT_CXX_MODULES 1
+// #undef BOOST_UT_DISABLE_MODULE // not necessary anymore
+
+#include "ut.hpp"

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -5,16 +5,17 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
-export module boost.ut;
-export import std;
+#if defined(BOOST_UT_CXX_MODULES)
 #define BOOST_UT_EXPORT export
 #else
 #pragma once
 #define BOOST_UT_EXPORT
 #endif
 
+#if !defined(BOOST_UT_CXX_MODULES)
 #include <version>
+#endif
+
 #if defined(_MSC_VER)
 #pragma push_macro("min")
 #pragma push_macro("max")
@@ -68,6 +69,7 @@ export import std;
 #define __has_builtin(...) __has_##__VA_ARGS__
 #endif
 
+#if !defined(BOOST_UT_CXX_MODULES)
 #include <algorithm>
 #include <array>
 #include <chrono>
@@ -101,6 +103,7 @@ export import std;
 #if __has_include(<source_location>)
 #include <source_location>
 #endif
+#endif // cxx modules
 
 struct unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_ {
 };


### PR DESCRIPTION
Problem:
It is hard to use cxx modules in a single header file.

Solution:
It should be separated into a .cppm file.

Issue: #669

Reviewers:
@kris-jusiak

Note that I'm not expert on boost/ut, I just happened to use its module system yesterday, I liked it a lot but needed to adapt it... I think this change is good.
Anyway, I broke the BOOST_UT_DISABLE_MODULE, because it was easier to create a logic where modules are disabled by default (which is 99% the case), and then, the .cppm file creates a definition BOOST_UT_CXX_MODULES 1, allowing the .hpp to set BOOST_UT_EXPORT export, and also rejecting all sorts of #include in the hpp.
Maybe it's best to remove it from CMakeLists.txt and just assume modules are disabled, unless someone decides to use the .cppm, which will automatically enable BOOST_UT_CXX_MODULES.

I also needed to maintain unistd on global fragment, it was the only one... maybe it's because it's C, not C++...

Finally, I added .cppm file on include/boost folder, which is not ideal, I guess... I believe some src/ or src/boost would be more suitable, but since these things are already very confusing, maybe include/ is also acceptable.

I also tried to adapt the CMakeLists.txt with the following: 
target_sources(ut  PUBLIC  FILE_SET CXX_MODULES FILES   include/boost/ut.cppm) 

However, I think this requires higher version of CMake... I'm using the 4.0.0, which is highly experimental, but it supports `import std;` for both GCC and Clang... I need to check which lower version of CMake has some minimum support for cppm module files, but maybe it's just too soon to do it... adding an example with an experimental higher CMake version is better perhaps (but one may need to copy the cppm file manually...). Sorry, I'm not expert in CMake either, but it's working fine!

