### PR TITLE
naming struct required for gcc 15

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2805,11 +2805,11 @@ namespace terse {
 #pragma clang diagnostic ignored "-Wunused-comparison"
 #endif
 
-[[maybe_unused]] constexpr struct {
+[[maybe_unused]] constexpr struct placeholder_gcc_t {
 } _t;
 
 template <class T>
-constexpr auto operator%(const T& t, const decltype(_t)&) {
+constexpr auto operator%(const T& t, const placeholder_gcc_t&) {
   return detail::value<T>{t};
 }
 


### PR DESCRIPTION
Problem:
GCC 15 complains of using an unnamed struct.

Solution:
Naming the struct with some random placeholder name.
After this change, it works fine in gcc 15 with cxx modules.

Issue: #671

Reviewers:
@kris-jusiak 
