### PR TITLE
Add newline after reporting a SKIPPED test

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1777,7 +1777,7 @@ class reporter_junit {
       if (report_type_ == CONSOLE) {
         lcout_ << '\n' << std::string((2 * active_test_.size()) - 2, ' ');
         lcout_ << "Running \"" << test_event.name << "\"... ";
-        lcout_ << color_.skip << "SKIPPED" << color_.none;
+        lcout_ << color_.skip << "SKIPPED" << color_.none << '\n';
       }
       reset_printer();
       pop_scope(test_event.name);


### PR DESCRIPTION
The `reporter` correctly adds a newline after `SKIPPED`, but `reporter_junit` doesn't. 

Problem:
- When skipping a test, the console reporter does not add a newline after printing `SKIPPED`.

Solution:
- Adding a newline after printing `SKIPPED`.

Issue: #653 

Reviewers:
@kris-jusiak 
