### PR TITLE
Small improvement in README, to directly indicate the module cppm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There are quite a few problems with the approach above
 
 `UT` is trying to address these issues by simplifying testing experience with a few simple steps:
 
-* Just get a single [header/module](https://github.com/boost-ext/ut/blob/master/include/boost/ut.hpp)
+* Just get a single [header](https://github.com/boost-ext/ut/blob/master/include/boost/ut.hpp) or [module+header](https://github.com/boost-ext/ut/blob/master/include/boost/ut.cppm)
 * Integrate it into your project
 * Learn a few simple concepts ([expect, test, suite](#api))
 


### PR DESCRIPTION
Problem:
Not a real problem, but header/module on README used to imply a single file, but now the files are different... maybe it's best for newcomers to understand that two files are needed for modules, but a single one is needed for header-only, as usual.

Solution:
Small change in README, pointing to both files independently.

Issue: Didn't open any.

Reviewers:
@kris-jusiak 
