### PR TITLE
support bazel build, closes #680

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,11 @@
+common --enable_bzlmod
+build --enable_platform_specific_config
+
+build:gcc15   --cxxopt=-std=c++23 --action_env=CC=/usr/bin/g++-15
+build:clang19 --cxxopt=-std=c++23 --action_env=CC=/usr/bin/clang++-19
+build:vs2019 --cxxopt=/std:c++20
+build:vs2022 --cxxopt=/std:c++20
+
+build:windows --config=vs2022
+build:linux --cxxopt=-std=c++20
+build:macos --cxxopt=-std=c++20

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ install_dir/
 cmake_build*/
 compile_commands.json
 .cache/
+bazel-*
+MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,7 @@
+
+cc_library(
+    name = "ut",
+    hdrs = ["include/boost/ut.hpp"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "ut")
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,0 +1,6 @@
+
+cc_binary(
+    name = "example_main",
+    srcs = ["main.cpp"],
+    deps = ["//:ut"],
+)


### PR DESCRIPTION
Problem:
Currently there's no support for bazel build

Solution:
support bazel build
Necessary files are: MODULE.bazel and BUILD.bazel
Support file are: example/BUILD.bazel
To run this, just install bazel (recommended through NVM/NPM bazelisk package):  `$ bazel build ...`

Issue: #680

Reviewers:
@kris-jusiak 
