### PR TITLE
Don't specify C++ standard when modules are on, and don't deal with uuid.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-option(BOOST_UT_DISABLE_MODULE "Disable ut module" OFF)
+option(BOOST_UT_DISABLE_MODULE "Disable ut module" ON)
 
 if(NOT BOOST_UT_DISABLE_MODULE)
 cmake_minimum_required(VERSION 4.0.0)


### PR DESCRIPTION
Problem:
Currently, modules don't work if I'm using cpp26 and the library is using cpp23.
Also enabling modules is the library consumers responsiblity, library shouldn't set uuid's

Solution:
Don't specify language standard, don't set uuids if modules are enabled

Issue: #

Reviewers:
@
