### PR TITLE
Improve the result formatting and remove the repeated log messages

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2048,8 +2048,8 @@ class runner {
     if (not dry_run_) {
       report_summary();
     }
-    std::cout << "\n========================================================"
-                 "=======================";
+    std::cout << "\nCompleted =============================================="
+                 "=======================\n";
     if (should_run and fails_) {
       std::exit(-1);
     }
@@ -2325,7 +2325,7 @@ struct log {
   struct next {
     template <class TMsg>
     auto& operator<<(const TMsg& msg) {
-      //on<TMsg>(events::log{' '});
+      on<TMsg>(events::log{' '});
       on<TMsg>(events::log{msg});
       return *this;
     }
@@ -2333,7 +2333,7 @@ struct log {
 
   template <class TMsg>
   auto operator<<(const TMsg& msg) -> next {
-    //on<TMsg>(events::log{'\n'});
+    on<TMsg>(events::log{'\n'});
     on<TMsg>(events::log{msg});
     return next{};
   }


### PR DESCRIPTION
Problem:
- the result formatting can be improved, which can enhance readability
- the repeated log messages need to be corrected

Solution:
- adjust the result formatting

Issue: #690 #694 

Note:
There are 3 sample codes, which can be applied to view the changed result formatting.
case 1: from https://github.com/boost-ext/ut/issues/690
```
#include <boost/ut.hpp>
using namespace boost::ut;
suite<"basic suite"> tests = [] {
    "test 1"_test = [] {
        expect(true);
        };
    };
int main(int argc, const char* argv[]) {
    boost::ut::detail::cfg::show_successful_tests = true;
}
```
results
```
UT starts =====================================================================
Running test "test 1"... PASSED
Suite 'basic suite': all tests passed (1 asserts in 1 tests)
Completed =====================================================================

```
case2: from https://github.com/boost-ext/ut/issues/694
```
#include <boost/ut.hpp>
using namespace boost; // nothrow is ambiguous
using namespace boost::ut;
constexpr auto sum(auto... values) { return (values + ...); }
int main() {
    using namespace boost::ut;
    "sum"_test = [] {
        expect(2 == 0_i) << "message";
        expect(sum(2, 2) == 3_i);
        expect(sum(1, 2) > 0_i and 41_i == sum(40, 2));
        };
}
```
results
```
UT starts =====================================================================
Running test "sum"...
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:23 - test condition: [2 == 0] message
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:24 - test condition: [4 == 3]
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:25 - test condition: [(3 > 0 and 41 == 42)]
===============================================================================
Suite global
tests:   1 | 1 failed
asserts: 3 | 0 passed | 3 failed
Completed =====================================================================

```
case3: multilayer tests
```
#include <boost/ut.hpp>
using namespace boost::ut;
suite<"basic suite"> tests = [] {
    "test A"_test = [] {
        expect(true);
        expect(1 != 1_i); // false
        };
    "test B"_test = [] {
        expect(true);
        };
    };
int main() {
    boost::ut::detail::cfg::show_successful_tests = true;
    "case 1"_test = [] {
        expect(1 == 1_i);
        expect(2 != 2_i); // false
        expect(3 != 3_i); // false
        "case 1.1"_test = [] {
            expect(4 == 4_i);
            expect(5 != 5_i); // false
            };
        "case 1.2"_test = [] {
            expect(6 == 6_i);
            expect(7 != 7_i); // false
            "case 1.2.1"_test = [] {
                expect(8 == 8_i);
                expect(9 != 9_i); // false
                };
            skip / "test 1.2.2"_test = [] {
                expect(true) << "should not fire!";
                };
            };
        };
    skip / "test 2"_test = [] {
        expect(false) << "should not fire!";  // skipped false
        };
    expect(10 != 10_i); // false
    "case 3"_test = [] {
        expect(11 == 11_i);
        };
    expect(12 != 12_i); // false
	"case 4"_test = [] {
        expect(13 == 13_i);
        expect(14 == 14_i);
        expect(15 != 15_i); // false
        };
    expect(16 != 16_i); // false
}
```
results
```
UT starts =====================================================================
Running test "case 1"...
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:45 - test condition: [2 != 2]
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:46 - test condition: [3 != 3]
  Running test "case 1.1"...
  FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:49 - test condition: [5 != 5]
  Running test "case 1.2"...
  FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:53 - test condition: [7 != 7]
    Running test "case 1.2.1"...
    FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:56 - test condition: [9 != 9]
    Running "test 1.2.2"... SKIPPED
Running "test 2"... SKIPPED
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:66 - test condition: [10 != 10]
Running test "case 3"... PASSED
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:70 - test condition: [12 != 12]
Running test "case 4"...
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:74 - test condition: [15 != 15]
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:76 - test condition: [16 != 16]
Running test "test A"...
FAILED in: D:\Notes\FromGitHub\BoostUtTest\Source.cpp:35 - test condition: [1 != 1]
Running test "test B"... PASSED
===============================================================================
Suite global
tests:   3 | 2 failed
asserts: 16 | 7 passed | 9 failed
===============================================================================
Suite basic suite
tests:   2 | 1 failed
asserts: 3 | 2 passed | 1 failed
Completed =====================================================================

```

Reviewers:
@kris-jusiak 
