### PR TITLE
Correct functions to prevent dangling string

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -3078,11 +3078,11 @@ struct suite {
 
 [[maybe_unused]] inline auto log = detail::log{};
 [[maybe_unused]] inline auto that = detail::that_{};
-[[maybe_unused]] constexpr auto test = [](const auto name) {
+[[maybe_unused]] constexpr auto test = [](const auto& name) {
   return detail::test{"test", name};
 };
 [[maybe_unused]] constexpr auto should = test;
-[[maybe_unused]] inline auto tag = [](const auto name) {
+[[maybe_unused]] inline auto tag = [](const auto& name) {
   return detail::tag{{name}};
 };
 [[maybe_unused]] inline auto skip = tag("skip");
@@ -3139,19 +3139,19 @@ template <class T>
 }
 
 namespace bdd {
-[[maybe_unused]] constexpr auto feature = [](const auto name) {
+[[maybe_unused]] constexpr auto feature = [](const auto& name) {
   return detail::test{"feature", name};
 };
-[[maybe_unused]] constexpr auto scenario = [](const auto name) {
+[[maybe_unused]] constexpr auto scenario = [](const auto& name) {
   return detail::test{"scenario", name};
 };
-[[maybe_unused]] constexpr auto given = [](const auto name) {
+[[maybe_unused]] constexpr auto given = [](const auto& name) {
   return detail::test{"given", name};
 };
-[[maybe_unused]] constexpr auto when = [](const auto name) {
+[[maybe_unused]] constexpr auto when = [](const auto& name) {
   return detail::test{"when", name};
 };
-[[maybe_unused]] constexpr auto then = [](const auto name) {
+[[maybe_unused]] constexpr auto then = [](const auto& name) {
   return detail::test{"then", name};
 };
 
@@ -3283,10 +3283,10 @@ class steps {
 }  // namespace bdd
 
 namespace spec {
-[[maybe_unused]] constexpr auto describe = [](const auto name) {
+[[maybe_unused]] constexpr auto describe = [](const auto& name) {
   return detail::test{"describe", name};
 };
-[[maybe_unused]] constexpr auto it = [](const auto name) {
+[[maybe_unused]] constexpr auto it = [](const auto& name) {
   return detail::test{"it", name};
 };
 }  // namespace spec

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -2240,8 +2240,16 @@ struct test_location {
 
 struct test {
   std::string_view type{};
+  std::optional<std::string> backingName;
   std::string_view name{};
   std::vector<std::string_view> tag{};
+
+  test(std::string_view t, std::string_view sv) : type(t), name(sv) {}
+  test(std::string_view t, const std::string& s) : type(t), name(s) {}
+  test(std::string_view t, const char* s) : type(t), name(s) {}
+  template <std::size_t N>
+  test(std::string_view t, const char (&s)[N]) : type(t), name(s) {}
+  test(std::string_view t, std::string&& s) : type(t), backingName(std::move(s)), name(*backingName) {}
 
   template <class... Ts>
   constexpr auto operator=(test_location<void (*)()> _test) {
@@ -3078,8 +3086,8 @@ struct suite {
 
 [[maybe_unused]] inline auto log = detail::log{};
 [[maybe_unused]] inline auto that = detail::that_{};
-[[maybe_unused]] constexpr auto test = [](const auto& name) {
-  return detail::test{"test", name};
+[[maybe_unused]] constexpr auto test = [](auto&& name) {
+  return detail::test{"test", std::forward<decltype(name)>(name)};
 };
 [[maybe_unused]] constexpr auto should = test;
 [[maybe_unused]] inline auto tag = [](const auto& name) {
@@ -3139,20 +3147,20 @@ template <class T>
 }
 
 namespace bdd {
-[[maybe_unused]] constexpr auto feature = [](const auto& name) {
-  return detail::test{"feature", name};
+[[maybe_unused]] constexpr auto feature = [](auto&& name) {
+  return detail::test{"feature", std::forward<decltype(name)>(name)};
 };
-[[maybe_unused]] constexpr auto scenario = [](const auto& name) {
-  return detail::test{"scenario", name};
+[[maybe_unused]] constexpr auto scenario = [](auto&& name) {
+  return detail::test{"scenario", std::forward<decltype(name)>(name)};
 };
-[[maybe_unused]] constexpr auto given = [](const auto& name) {
-  return detail::test{"given", name};
+[[maybe_unused]] constexpr auto given = [](auto&& name) {
+  return detail::test{"given", std::forward<decltype(name)>(name)};
 };
-[[maybe_unused]] constexpr auto when = [](const auto& name) {
-  return detail::test{"when", name};
+[[maybe_unused]] constexpr auto when = [](auto&& name) {
+  return detail::test{"when", std::forward<decltype(name)>(name)};
 };
-[[maybe_unused]] constexpr auto then = [](const auto& name) {
-  return detail::test{"then", name};
+[[maybe_unused]] constexpr auto then = [](auto&& name) {
+  return detail::test{"then", std::forward<decltype(name)>(name)};
 };
 
 namespace gherkin {
@@ -3283,11 +3291,11 @@ class steps {
 }  // namespace bdd
 
 namespace spec {
-[[maybe_unused]] constexpr auto describe = [](const auto& name) {
-  return detail::test{"describe", name};
+[[maybe_unused]] constexpr auto describe = [](auto&& name) {
+  return detail::test{"describe", std::forward<decltype(name)>(name)};
 };
-[[maybe_unused]] constexpr auto it = [](const auto& name) {
-  return detail::test{"it", name};
+[[maybe_unused]] constexpr auto it = [](auto&& name) {
+  return detail::test{"it", std::forward<decltype(name)>(name)};
 };
 }  // namespace spec
 


### PR DESCRIPTION
Problem:
- In ut.hpp, detail::test::name is std::string_view. there are many functions, which can deliver dangling string to detail::test::name.

For example, 
```cpp
[[maybe_unused]] constexpr auto test = [](const auto name) {
  return detail::test{"test", name};
};
```

The following examples can have wrong results
Example 1: modified from [#696](https://github.com/boost-ext/ut/issues/696)
```cpp
#include <boost/ut.hpp>
void tt(const std::string& folder, std::function<void(const std::string&)>&& run)
{
    boost::ut::test(folder) = [&] {
        for (const std::string& name : {
            "11111111111111111111111111111111111111111111111111111111",
            "2222222222222222222222222222222222222222222222222222222222",
            "2222222222222222222222222222222222222222222222222222222222",
            "333333333333333333333333333333333333333333333333333333333333"})
        {
            run(name);
        }
    };
}
boost::ut::suite<"Main"> main_suite = [] {
    using namespace boost::ut;
    tt("main", [](const std::string& name) {
        should("parametrized " + name) = [] {
            expect(true);
            expect(false);
        };
    });
};
int main() {
}
```
Expected results 1
```
UT starts =====================================================================
Running test "main"...
  Running test "parametrized 11111111111111111111111111111111111111111111111111111111"...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "parametrized 2222222222222222222222222222222222222222222222222222222222"...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "parametrized 2222222222222222222222222222222222222222222222222222222222"...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "parametrized 333333333333333333333333333333333333333333333333333333333333"...
  FAILED in: ...\example.cpp:20 - test condition: [false]
===============================================================================
Suite Main
tests:   1 | 1 failed
asserts: 8 | 4 passed | 4 failed
Completed =====================================================================
```
Possible results 1
```
UT starts =====================================================================
Running test "ain"...
  Running test "楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥?...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥?...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥楥?...
  FAILED in: ...\example.cpp:20 - test condition: [false]
  Running test "迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋迋?...
  FAILED in: ...\example.cpp:20 - test condition: [false]
===============================================================================
Suite Main
tests:   1 | 1 failed
asserts: 8 | 4 passed | 4 failed
Completed =====================================================================
```
Example results 2
```cpp
#include <boost/ut.hpp>
using namespace boost::ut;
int main() {
	auto t1 = test(std::string("hello temporary"));
	std::cout << t1.name << "\n";

	std::string folder = "my_folder";
	auto t2 = test(folder + "_case");
	std::cout << t2.name << "\n";

	std::string name = "ABC";
	auto t3 = test("parametrized " + name);
	std::cout << t3.name << "\n";
}
```
Expected results 2
```
hello temporary
my_folder_case
parametrized ABC
```
Possible results 2
```
ello temporary
y_folder_case
楥楥楥楥楥楥楥楥
```

Solution:
- Improve struct test {} and some functions

Issue: #696

Reviewers:
@kris-jusiak 
